### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Volue AS'
 author = 'Volue AS'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.0'
+release = '0.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volue.mesh"
-version = "0.0.0"
+version = "0.1.0"
 description = ""
 license = "Proprietary"
 authors = ["Volue AS <erik.nyhus@volue.com>"]

--- a/src/volue/mesh/__init__.py
+++ b/src/volue/mesh/__init__.py
@@ -1,6 +1,6 @@
 """Client library for Volue Energy's Mesh software."""
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"
 
 import grpc
 


### PR DESCRIPTION
@torsannes @pjaall: I suggest we bump the minor version once every sprint until we start closing in on something stable. That'll both somewhat ease communication and we can do milestones that correspond to both versions and sprints.