### PR TITLE
Change Arrow schema of timeseries timestamps

### DIFF
--- a/src/volue/mesh/_timeseries.py
+++ b/src/volue/mesh/_timeseries.py
@@ -38,7 +38,7 @@ class Timeseries:
     """
 
     schema = pa.schema([
-        pa.field('utc_time', pa.date64()),
+        pa.field('utc_time', pa.timestamp('ms')),
         pa.field('flags', pa.uint32()),
         pa.field('value', pa.float64()),
     ])  # The pyarrow schema used for timeseries points.

--- a/src/volue/mesh/examples/write_timeseries_points.py
+++ b/src/volue/mesh/examples/write_timeseries_points.py
@@ -10,15 +10,15 @@ def write_timeseries_points(session: Connection.Session):
 
     # Defining a time interval to write timeseries to
     start = datetime(2016, 5, 1)
-    end = datetime(2016, 5, 14)
+    end = datetime(2016, 5, 2)  # end time must be greater than last point to be read/written
 
     # Defining the data we want to write
     # Mesh data is organized as an Arrow table with the following schema:
-    # utc_time - [pa.date64] as a UTC Unix timestamp expressed in milliseconds
+    # utc_time - [pa.timestamp('ms')] as a UTC Unix timestamp expressed in milliseconds
     # flags - [pa.uint32]
     # value - [pa.float64]
     arrays = [
-        pa.array([1462060800000, 1462064400000, 1462068000000]),
+        pa.array([datetime(2016, 5, 1), datetime(2016, 5, 1, 1),  datetime(2016, 5, 1, 2)]),
         pa.array([0, 0, 0]),
         pa.array([0.0, 10.0, 1000.0])]
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)

--- a/src/volue/mesh/examples/write_timeseries_points_async.py
+++ b/src/volue/mesh/examples/write_timeseries_points_async.py
@@ -12,15 +12,15 @@ async def write_timeseries_points(session: Connection.Session):
 
     # Defining a time interval to write timeseries to
     start = datetime(2016, 5, 1)
-    end = datetime(2016, 5, 14)
+    end = datetime(2016, 5, 2)  # end time must be greater than last point to be read/written
 
     # Defining the data we want to write
     # Mesh data is organized as an Arrow table with the following schema:
-    # utc_time - [pa.date64] as a UTC Unix timestamp expressed in milliseconds
+    # utc_time - [pa.timestamp('ms')] as a UTC Unix timestamp expressed in milliseconds
     # flags - [pa.uint32]
     # value - [pa.float64]
     arrays = [
-        pa.array([1462060800000, 1462064400000, 1462068000000]),
+        pa.array([datetime(2016, 5, 1), datetime(2016, 5, 1, 1),  datetime(2016, 5, 1, 2)]),
         pa.array([0, 0, 0]),
         pa.array([0.0, 10.0, 1000.0])]
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)

--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -32,7 +32,7 @@ def test_can_serialize_and_deserialize_write_timeserie_request():
     end = datetime(year=2016, month=12, day=25, hour=0, minute=0, second=0)  # 25/12/2016 00:00:00
 
     arrays = [
-        pa.array([1462060800000, 1462064400000, 1462068000000]),
+        pa.array([datetime(2016, 5, 1), datetime(2016, 5, 1, 1),  datetime(2016, 5, 1, 2)]),
         pa.array([0, 0, 0]),
         pa.array([0.0, 0.0, 0.0])]
 

--- a/src/volue/mesh/tests/test_utilities/utilities.py
+++ b/src/volue/mesh/tests/test_utilities/utilities.py
@@ -140,11 +140,11 @@ def get_timeseries_entry_2():
     )
 
     # Mesh data is organized as an Arrow table with the following schema:
-    # utc_time - [pa.date64] as a UTC Unix timestamp expressed in milliseconds
+    # utc_time - [pa.timestamp('ms')] as a UTC Unix timestamp expressed in milliseconds
     # flags - [pa.uint32]
     # value - [pa.float64]
     arrays = [
-        pa.array([1462060800000, 1462064400000, 1462068000000]),
+        pa.array([datetime(2016, 5, 1), datetime(2016, 5, 1, 1),  datetime(2016, 5, 1, 2)]),
         pa.array([0, 0, 0]),
         pa.array([0.0, 10.0, 1000.0])]
     modified_table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)


### PR DESCRIPTION
Change Arrow schema of timestamps for gRPC timeseries API from date64 to timestamp('ms').
Fixes #91.

Needs Mesh server with the following PR merged:
https://github.com/PowelAS/sme-mesh/pull/1501