### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
     timeout-minutes: 60
 

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
       fail-fast: false
     timeout-minutes: 60
 
@@ -68,8 +68,8 @@ jobs:
           sudo add-apt-repository --yes ppa:deadsnakes/ppa
           sudo apt-get install --yes python${{ matrix.python-version }}
           sudo apt-get install --yes python${{ matrix.python-version }}-distutils
-          sudo apt-get install --yes python3-pip
-          sudo apt-get install --yes libkrb5-dev
+          curl -sS https://bootstrap.pypa.io/get-pip.py | python${{ matrix.python-version }}
+          sudo apt-get install --yes libkrb5-dev gcc
           sudo apt-get install --yes python${{ matrix.python-version }}-dev
           python${{ matrix.python-version }} -m pip install git+https://github.com/Volue-Public/energy-mesh-python@${{ github.ref }}
           python${{ matrix.python-version }} ./repo/src/volue/mesh/examples/get_version.py

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -35,6 +35,28 @@ I get a SSL_ERROR_SSL. What am I doing wrong?
 If your server is set up to not use TLS and you try to connect using a secure connection you will get this error. Either change the server to use TLS (Configuration.Network.GRPC.EnableTLS(true)) or change you client code to connect without a secure connection.
 
 
+I get error with building dependencies when installing `volue.mesh` on Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This error can have multiple causes. Some things to check are:
+
+#. Is pip upgraded to the latest version?
+#. In particular if there is a problem with building wheel for `kerberos`
+   dependency, make sure that `libkrb5-dev`, `python3-dev` and `gcc` are
+   installed. For example:
+
+::
+
+  sudo apt-get install libkrb5-dev python3.10-dev gcc
+
+We are automatically verifying that Mesh Python SDK is working for all
+supported Python versions using GitHub Actions. Please take a look at the
+GitHub Action workflow file to see how are we preparing Windows and Ubuntu
+environments:
+
+.. literalinclude:: /../../.github/workflows/usage.yml
+   :language: yaml
+
 Other
 *****
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ Prerequisites
 **************
 
 - Mesh server with gRPC enabled.
-- Python [3.7.1, 3.8, 3.9]
+- Python [3.7.1, 3.8, 3.9, 3.10]
 
 Getting help
 ---------------

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -3,6 +3,33 @@ Versions
 
 Depending on the Mesh Server version you intend to communicate with a compatible version of Mesh Python SDK is needed.
 
+`Mesh Python SDK version 1.1.0 (Release Candidate) <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.1.0>`_
+*****************************************************************************************************************************
+
+------------
+
+Compatible with
+~~~~~~~~~~~~~~~~~~
+
+- Mesh server version >= 2.6.1
+- Python [3.7.1, 3.8 3.9 and 3.10]
+- Tested with Mesh server version 2.6.1.8
+
+New features
+~~~~~~~~~~~~~~~~~~
+
+- Support for Python 3.10
+
+Install instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See instructions at :ref:`Setup for users` and use the following:
+
+::
+
+    python -m pip install --force-reinstall git+https://github.com/Volue-Public/energy-mesh-python@v1.1.0
+
+
 `Mesh Python SDK version 1.0.0 (Release Candidate) <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.0.0>`_
 *****************************************************************************************************************************
 

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -20,6 +20,9 @@ New features
 
 - Support for Python 3.10
 
+.. warning::
+    Python 3.7.1 support will dropped in the next Mesh Python SDK release.
+
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -18,7 +18,7 @@ Compatible with
 New features
 ~~~~~~~~~~~~~~~~~~
 
-- Support for Python 3.10
+- Support for Python 3.10 :pull:`93`
 
 .. warning::
     Python 3.7.1 support will dropped in the next Mesh Python SDK release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.1" #pandas require python 3.7.1 or above
+python = ">=3.7.1,<3.11"  # pandas requires python 3.7.1 or above, numpy (one of the dependencies) requires python below 3.11
 grpcio = "^1.37.0"
-pyarrow = "^4.0.1"
+pyarrow = ">=7.0.0"
 protobuf = "^3.20.1"
 winkerberos = { version = "^0.8.0", markers = "sys_platform == 'win32'" }
 kerberos = { version = "^1.3.1", markers = "sys_platform == 'linux'" }


### PR DESCRIPTION
~~Put on hold - due to current incompatibility of pip/distutil (distutil is needed for kerberos on Ubuntu) with Python 3.10.~~

~~For windows github actions are working correctly for python 3.10.~~

We are supporting Python 3.10 now.