### PR TITLE
Disable fail-fast option for GitHub actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+      fail-fast: false
 
     steps:
       - uses: actions/setup-python@v2


### PR DESCRIPTION
By default fail-fast is enabled thus if one GitHub action job fails all other are cancelled.
Currently each job is running different Python version so it is worth to not cancel them and see if they pass or fail - maybe there is a breaking change only for one version of Python?