### PR TITLE
Fix 'usage' GitHub action

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -36,16 +36,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
           MESH_SERVICE_TAG: 'MeshService_v2.2.0'
 
-      # because the branch name will be used in different steps (using different shells)
-      # create a separate step for just getting the current branch name
-      - name: Get branch name
+      # because the ref name (either branch name or pull request number)
+      # will be used in different steps (using different shells)
+      # create a separate step for just getting the ref name
+      - name: Get ref name
         shell: bash
-        run: echo "::set-output name=branch_name::$(echo ${GITHUB_REF##*/})"
-        id: get_branch_name
+        run: echo "::set-output name=ref_name::$(echo ${GITHUB_REF})"
+        id: get_ref_name
 
       - name: Install and test Python SDK (Windows)
         run: |
-          python -m pip install git+https://${{ secrets.OAUTH_TOKEN }}@github.com/PowelAS/sme-mesh-python@${{ steps.get_branch_name.outputs.branch_name }}
+          python -m pip install git+https://${{ secrets.OAUTH_TOKEN }}@github.com/PowelAS/sme-mesh-python@${{ steps.get_ref_name.outputs.ref_name }}
           python -m pip install pytest pytest-asyncio
           python -m pytest --pyargs volue.mesh.tests -m "unittest or server"
 
@@ -67,6 +68,6 @@ jobs:
           sudo apt-get install --yes python3-pip
           sudo apt-get install --yes libkrb5-dev
           sudo apt-get install --yes python${{ matrix.python-version }}-dev
-          python${{ matrix.python-version }} -m pip install git+https://${{ secrets.OAUTH_TOKEN }}@github.com/PowelAS/sme-mesh-python@${{ steps.get_branch_name.outputs.branch_name }}
+          python${{ matrix.python-version }} -m pip install git+https://${{ secrets.OAUTH_TOKEN }}@github.com/PowelAS/sme-mesh-python@${{ steps.get_ref_name.outputs.ref_name }}
           python${{ matrix.python-version }} -m pip install pytest pytest-asyncio
           python${{ matrix.python-version }} -m pytest --pyargs volue.mesh.tests -m "unittest or server"


### PR DESCRIPTION
Current behavior was that Python SDK pip package was installed from master branch. This had two consequences:

- if a pull request introduced breaking change it was not catched by usage.yml tests
- if there was a need to update dependencies or support a new platform (like Python 3.10) that requires changes in dependencies then if master package was not compatible (due to e.g. dependencies) it would always fail.

Fix it to install pip package from the branch (that triggered the action) instead.