### PR TITLE
Add copy button to code blocks in the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.coverage'
+    'sphinx.ext.coverage',
+    'sphinx_copybutton'
 ]
 
 # Options for: sphinx.ext.napoleon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ flake8 = "^3.9.2"
 pytest = "^6.2.5"
 pytest-asyncio = "^0.15.1"
 pandas = "^1.3.4"
+sphinx_copybutton = ">=0.4.0"
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Introducing new level of awesomeness:

![image](https://user-images.githubusercontent.com/88330807/147912211-a6f6a965-8e9b-43f5-81f9-f14d8dab20b8.png)
