### PR TITLE
Fix tests with wrong self-reference @T for TimeseriesAttribute with single timeseries entry

### DIFF
--- a/src/volue/mesh/tests/test_aio_connection.py
+++ b/src/volue/mesh/tests/test_aio_connection.py
@@ -742,7 +742,7 @@ async def test_statistical_sum():
 
         try:
             reply_timeseries = await session.statistical_functions(
-                MeshObjectId(full_name=full_name), start_time, end_time).sum()
+                MeshObjectId(full_name=full_name), start_time, end_time).sum('some_query')
             assert reply_timeseries.is_calculation_expression_result
         except grpc.RpcError as e:
             pytest.fail(f"Could not read timeseries points: {e}")

--- a/src/volue/mesh/tests/test_connection.py
+++ b/src/volue/mesh/tests/test_connection.py
@@ -709,7 +709,7 @@ def test_statistical_sum():
 
         try:
             reply_timeseries = session.statistical_functions(
-                MeshObjectId(full_name=full_name), start_time, end_time).sum()
+                MeshObjectId(full_name=full_name), start_time, end_time).sum('some_query')
             assert reply_timeseries.is_calculation_expression_result
         except grpc.RpcError as e:
             pytest.fail(f"Could not read timeseries points: {e}")


### PR DESCRIPTION
See #161 
This PR is only a W/A where search query won't find any results, so the result will be an empty time series.