### PR TITLE
Fix use cases

### DIFF
--- a/src/volue/mesh/use_cases/use_cases.py
+++ b/src/volue/mesh/use_cases/use_cases.py
@@ -9,7 +9,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pyarrow as pa
 
-from volue.mesh import Connection, MeshObjectId, Timeseries, _from_proto_guid
+from volue.mesh import Connection, MeshObjectId, Timeseries
+from volue.mesh._common import _from_proto_guid
 from volue.mesh.calc import transform as Transform
 from volue.mesh.calc.common import Timezone
 from volue.mesh.proto.core.v1alpha import core_pb2


### PR DESCRIPTION
Fix the import.

@jbbakeng somehow I missed that when reviewing #170. Why did we changed `from_proto_guid` to `_from_proto_guid` which indicates it's a private function? Some of the functions from `common` can be used by externally, like in the `use_cases.py`.
