### PR TITLE
GitHub Action improvement

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Install and test Python SDK (Windows)
         run: |
-          python non_existing_script.py
-          if ($LASTEXITCODE) { exit $LASTEXITCODE }
           python -m pip install git+https://${{ secrets.OAUTH_TOKEN }}@github.com/PowelAS/sme-mesh-python@${{ github.ref }}
           python -m pip install pytest pytest-asyncio pandas
           python -m pytest --pyargs volue.mesh.tests -m "not authentication"


### PR DESCRIPTION
Simplify `usage` GitHub action - use directly `ref` var from `github` context.

Additionally treat this as a playground for checking why PowerShell commands are not always returning error code.