### PR TITLE
Limit GitHub action job timeout

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
       fail-fast: false
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build and publish
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout origin/master to master/
       uses: actions/checkout@v2

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
       fail-fast: false
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
From time to time the GitHub action job hangs while populating test models (CommandLineRequests is waiting to connect to the Mesh server). E.g.:
https://github.com/PowelAS/sme-mesh-python/runs/5972186225?check_suite_focus=true

The default timeout for a job is 6 hours, so after 6h it gets cancelled.
Because currently our jobs finish in less than 20 mins, set more aggressive timeout limit - 1h.