### PR TITLE
Add factory methods to Connection classes

### DIFF
--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -23,8 +23,6 @@ from . import _base_connection
 
 
 class Connection(_base_connection.Connection):
-    """Represents a connection to a Mesh server."""
-
     class Session:
         """
         This class supports the with statement, because it's a contextmanager.

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -20,8 +20,6 @@ from volue.mesh import _base_connection
 
 
 class Connection(_base_connection.Connection):
-    """Represents a connection to a Mesh server."""
-
     class Session:
         """
         This class supports the async with statement, because it's an async contextmanager.

--- a/src/volue/mesh/tests/test_connection.py
+++ b/src/volue/mesh/tests/test_connection.py
@@ -27,8 +27,12 @@ from volue.mesh.tests.test_utilities.utilities import get_timeseries_2, get_time
 def test_read_timeseries_points():
     """Check that timeseries points can be read using timeseries key, UUID and full name"""
 
-    connection = Connection(sc.DefaultServerConfig.ADDRESS, sc.DefaultServerConfig.PORT,
-                            sc.DefaultServerConfig.ROOT_PEM_CERTIFICATE)
+    if not sc.DefaultServerConfig.ROOT_PEM_CERTIFICATE:
+        connection = Connection.insecure(sc.DefaultServerConfig.target())
+    else:
+        connection = Connection.with_tls(sc.DefaultServerConfig.target(),
+                                         sc.DefaultServerConfig.ROOT_PEM_CERTIFICATE)
+
     with connection.create_session() as session:
         timeseries, start_time, end_time, _, full_name = get_timeseries_2()
         try:

--- a/src/volue/mesh/tests/test_utilities/server_config.py
+++ b/src/volue/mesh/tests/test_utilities/server_config.py
@@ -13,5 +13,8 @@ class ServerConfig:
     ROOT_PEM_CERTIFICATE: str = ''
     KERBEROS_SERVICE_PRINCIPAL_NAME: str = 'HOST/example.companyad.company.com'
 
+    def target(self):
+        return f"{self.ADDRESS}:{self.PORT}"
+
 
 DefaultServerConfig: ServerConfig = ServerConfig()


### PR DESCRIPTION
Rework construction of `Connection`s to use explicit factory methods.

Old:

    Connection('localhost', 50051)
    Connection('localhost', 50051, root_certificates)
    Connection('localhost', 50051, root_certificates,
               kerberos_parameters)

New:

    Connection.insecure('localhost:50051')
    Connection.with_tls('localhost:50051', root_certificates)
    Connection.with_kerberos('localhost:50051', root_certificates
                             service_principal, user_principal)

While this doesn't give too much value in the code base as is, except
for explicitness, it opens up for adding more authentication methods
without making `__init__` completely unwieldy.

In addition I changed `(host, port)` to `target` to support more
gRPC addressing schemes.

Backwards compatability is preserved and only one test updated as
including all test, example and documentation changes in one PR ended up
being a bit extreme.