### PR TITLE
Final wrappers for gRPC interface

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,12 +3,6 @@ API documentation
 
 The Mesh Python API contains several packages, namespaces and modules.
 
-volue.mesh.proto.core.v1alpha
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: volue.mesh.proto.core.v1alpha.core_pb2_grpc
-.. automodule:: volue.mesh.proto.core.v1alpha.core_pb2
-
 volue.mesh
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/src/volue/mesh/__init__.py
+++ b/src/volue/mesh/__init__.py
@@ -7,7 +7,7 @@ from ._timeseries import Timeseries
 from ._timeseries_resource import TimeseriesResource
 from ._attribute import AttributeBase, TimeseriesAttribute
 from ._object import Object
-from ._common import MeshObjectId
+from ._common import AttributesFilter, UserIdentity, VersionInfo, MeshObjectId
 from ._credentials import Credentials
 from ._connection import Connection
 from .tests import *
@@ -25,5 +25,8 @@ __all__ = [
     'Object',
     'Timeseries',
     'TimeseriesResource',
+    'AttributesFilter',
+    'UserIdentity',
+    'VersionInfo',
     'MeshObjectId'
 ]

--- a/src/volue/mesh/_common.py
+++ b/src/volue/mesh/_common.py
@@ -2,7 +2,7 @@
 Common classes/enums/etc. for the Mesh API.
 """
 
-import uuid
+from __future__ import annotations
 from dataclasses import dataclass
 import datetime
 from typing import List, Optional
@@ -81,8 +81,8 @@ class AttributesFilter:
         Arg:      `tag_mask` is set to "ProductionAttributes,LocationAttributes"
         Response: All attributes with tag name "ProductionAttributes" or "LocationAttributes" will be returned.
         Note:     If attributes A1, A2 have tag "ProductionAttributes" and A3
-            has "LocationAttributes" then all three attributes (A1, A2 and A3) will be returned.
-            Exactly the same rules apply to `namespace_mask`.
+        has "LocationAttributes" then all three attributes (A1, A2 and A3) will be returned.
+        Exactly the same rules apply to `namespace_mask`.
 
     Example 3:
 
@@ -116,6 +116,63 @@ class AttributesFilter:
     namespace_mask: List[str] = None
     return_no_attributes: bool = False
 
+@dataclass
+class UserIdentity:
+    """Represents a Mesh server user identity.
+
+    display_name - a human readable name identifying this user. This name
+    should not be used as an unique identifier for the user as it may be
+    identical  between users and change over time.
+
+    source - security package name where the user identity came from.
+    It is not an unique identifier of the security package instance.
+
+    identifier - uniquely identifies the user within given `source` instance, but
+    not necessarily globally. Combining `source` and `identifier` does not guarantee
+    to get globally unique identifier for the user as there may be different
+    Active Directories using the same security packages (`source`) with
+    duplicated user identifiers. However such situation is rather unlikely.
+    """
+
+    display_name: str
+    source: str
+    identifier : str
+
+    @classmethod
+    def _from_proto(cls, proto_user_identity: core_pb2.UserIdentity) -> UserIdentity:
+        """Create a `UserIdentity` from protobuf UserIdentity.
+
+        Args:
+            proto_user_identity: protobuf UserIdentity returned from the gRPC method.
+        """
+        return cls(
+            display_name=proto_user_identity.display_name,
+            source=proto_user_identity.source,
+            identifier=proto_user_identity.identifier)
+
+@dataclass
+class VersionInfo:
+    """
+    Represents a Mesh server version information.
+
+    version - version number, e.g.: 2.5.2.32
+
+    name - friendly name of the Mesh server, e.g.: Volue Mesh Server
+    """
+
+    version: str
+    name: str
+
+    @classmethod
+    def _from_proto(cls, proto_version_info: core_pb2.VersionInfo) -> VersionInfo:
+        """Create a `VersionInfo` from protobuf VersionInfo.
+
+        Args:
+            proto_version_info: protobuf VersionInfo returned from the gRPC method.
+        """
+        return cls(
+            version=proto_version_info.version,
+            name=proto_version_info.name)
 
 @dataclass
 class MeshObjectId:

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -9,9 +9,10 @@ import uuid
 from google import protobuf
 import grpc
 
-from volue.mesh import Timeseries, MeshObjectId, AttributeBase, TimeseriesAttribute, TimeseriesResource, Object
+from volue.mesh import Timeseries, AttributesFilter, UserIdentity, VersionInfo, MeshObjectId, \
+    AttributeBase, TimeseriesAttribute, TimeseriesResource, Object
 from volue.mesh._attribute import _from_proto_attribute
-from volue.mesh._common import AttributesFilter, _to_proto_guid, _from_proto_guid, _to_protobuf_utcinterval, \
+from volue.mesh._common import _to_proto_guid, _from_proto_guid, _to_protobuf_utcinterval, \
     _read_proto_reply, _to_proto_timeseries, _to_proto_curve_type
 from volue.mesh.calc.forecast import ForecastFunctions
 from volue.mesh.calc.history import HistoryFunctions
@@ -293,13 +294,13 @@ class Connection(_base_connection.Connection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def get_version(self) -> core_pb2.VersionInfo:
-        response = self.mesh_service.GetVersion(protobuf.empty_pb2.Empty())
-        return response
+    def get_version(self) -> VersionInfo:
+        return VersionInfo._from_proto(
+            self.mesh_service.GetVersion(protobuf.empty_pb2.Empty()))
 
-    def get_user_identity(self) -> core_pb2.UserIdentity:
-        response = self.mesh_service.GetUserIdentity(protobuf.empty_pb2.Empty())
-        return response
+    def get_user_identity(self) -> UserIdentity:
+        return UserIdentity._from_proto(
+            self.mesh_service.GetUserIdentity(protobuf.empty_pb2.Empty()))
 
     def revoke_access_token(self) -> None:
         if self.auth_metadata_plugin is None:

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -11,9 +11,10 @@ from datetime import datetime
 from google import protobuf
 import grpc
 
-from volue.mesh import Timeseries, MeshObjectId, AttributeBase, TimeseriesAttribute, TimeseriesResource, Object
+from volue.mesh import Timeseries, AttributesFilter, UserIdentity, VersionInfo, MeshObjectId, \
+    AttributeBase, TimeseriesAttribute, TimeseriesResource, Object
 from volue.mesh._attribute import _from_proto_attribute
-from volue.mesh._common import AttributesFilter, _from_proto_guid, _to_proto_guid, _to_protobuf_utcinterval, \
+from volue.mesh._common import _from_proto_guid, _to_proto_guid, _to_protobuf_utcinterval, \
     _read_proto_reply, _to_proto_timeseries, _to_proto_curve_type
 from volue.mesh.calc.forecast import ForecastFunctionsAsync
 from volue.mesh.calc.history import HistoryFunctionsAsync
@@ -296,12 +297,13 @@ class Connection(_base_connection.Connection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def get_version(self):
-        return await self.mesh_service.GetVersion(protobuf.empty_pb2.Empty())
+    async def get_version(self) -> VersionInfo:
+        return VersionInfo._from_proto(
+            await self.mesh_service.GetVersion(protobuf.empty_pb2.Empty()))
 
-    async def get_user_identity(self):
-        response = await self.mesh_service.GetUserIdentity(protobuf.empty_pb2.Empty())
-        return response
+    async def get_user_identity(self) -> UserIdentity:
+        return UserIdentity._from_proto(
+            await self.mesh_service.GetUserIdentity(protobuf.empty_pb2.Empty()))
 
     async def revoke_access_token(self):
         if self.auth_metadata_plugin is None:

--- a/src/volue/mesh/use_cases/use_cases.py
+++ b/src/volue/mesh/use_cases/use_cases.py
@@ -9,8 +9,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pyarrow as pa
 
-from volue.mesh import Connection, MeshObjectId, Object, Timeseries, TimeseriesResource
-from volue.mesh._common import AttributesFilter, _from_proto_guid
+from volue.mesh import Connection, AttributesFilter, MeshObjectId, Object, Timeseries, TimeseriesResource 
 from volue.mesh.calc import transform as Transform
 from volue.mesh.calc.common import Timezone
 


### PR DESCRIPTION
* Added wrappers for `VersionInfo` and `UserIdentity`
* Moved `AttributesFilter` to `volue.mesh` init package - it should be accessible by the external clients
* "Fixed" indentation in `AttributesFilter` docstring - sphinx treated it as a warning
* Removed gRPC classes from API docs

As far as I know those were the last gRPC classes that were exposed to clients via our APIs.
Fixes #190 