### PR TITLE
Add RatingCurveAttribute

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -51,7 +51,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.5.2.32'
+          MESH_SERVICE_TAG: 'v2.5.2.33'
 
       # run explicitly run_tests.py script
       - name: Run tests

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -39,7 +39,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.5.2.32'
+          MESH_SERVICE_TAG: 'v2.5.2.33'
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package

--- a/src/volue/mesh/__init__.py
+++ b/src/volue/mesh/__init__.py
@@ -5,7 +5,7 @@ Client library for Volue Energy's Mesh software.
 from ._authentication import Authentication
 from ._timeseries import Timeseries
 from ._timeseries_resource import TimeseriesResource
-from ._attribute import AttributeBase, TimeseriesAttribute
+from ._attribute import AttributeBase, RatingCurveAttribute, TimeseriesAttribute
 from ._object import Object
 from ._common import AttributesFilter, UserIdentity, VersionInfo, MeshObjectId
 from ._credentials import Credentials
@@ -21,6 +21,7 @@ __all__ = [
     'Credentials',
     'Connection',
     'AttributeBase',
+    'RatingCurveAttribute',
     'TimeseriesAttribute',
     'Object',
     'Timeseries',

--- a/src/volue/mesh/tests/test_connection.py
+++ b/src/volue/mesh/tests/test_connection.py
@@ -22,7 +22,8 @@ import volue.mesh.tests.test_utilities.server_config as sc
 from volue.mesh.proto.core.v1alpha import core_pb2
 from volue.mesh.proto.type import resources_pb2
 from volue.mesh.tests.test_utilities.utilities import get_attribute_path_principal, get_timeseries_2, get_physical_timeseries, \
-    get_virtual_timeseries, get_timeseries_attribute_2, verify_timeseries_2, verify_plant_timeseries_attribute
+    get_virtual_timeseries, get_timeseries_attribute_2, verify_timeseries_2, verify_plant_timeseries_attribute, \
+    verify_plant_base_attribute
 
 
 @pytest.mark.database
@@ -829,7 +830,7 @@ def test_get_object():
         assert object.path == object_path
         assert object.type_name == "PlantElementType"
         assert object.owner_path == "Model/SimpleThermalTestModel/ThermalComponent.ThermalPowerToPlantRef"
-        assert len(object.attributes) == 23
+        assert len(object.attributes) == 25
 
         for attribute in object.attributes.values():
             assert attribute.name is not None
@@ -1259,6 +1260,25 @@ def test_get_double_attribute():
     with connection.create_session() as session:
         attribute = session.get_attribute(attribute_path=dbl_attribute_path, full_attribute_info=True)
         verify_double_attribute(attribute=attribute, dbl_attribute_path=dbl_attribute_path, attribute_name=attribute_name)
+
+@pytest.mark.database
+def test_get_rating_curve_attribute():
+    """
+    Check that 'get_attribute' with full attribute view retrieves a rating curve attribute.
+    """
+
+    connection = Connection(sc.DefaultServerConfig.ADDRESS, sc.DefaultServerConfig.PORT,
+                            sc.DefaultServerConfig.ROOT_PEM_CERTIFICATE)
+
+    attribute_name = "RatingCurveAtt"
+    attribute_path = get_attribute_path_principal() + attribute_name
+
+    with connection.create_session() as session:
+        attribute = session.get_attribute(attribute_path=attribute_path, full_attribute_info=True)
+        verify_plant_base_attribute(attribute, path=attribute_path, name=attribute_name)
+        assert attribute.definition.minimum_cardinality == 1
+        assert attribute.definition.maximum_cardinality == 1
+        assert attribute.definition_name == "TestRatingCurveDefinition"
 
 @pytest.mark.database
 def test_search_multiple_attributes():

--- a/src/volue/mesh/tests/test_utilities/utilities.py
+++ b/src/volue/mesh/tests/test_utilities/utilities.py
@@ -267,3 +267,12 @@ def verify_plant_timeseries_attribute(attribute: Union[AttributeBase, Timeseries
         assert attribute.definition.minimum_cardinality == 1
         assert attribute.definition.maximum_cardinality == 1
         assert attribute.definition.template_expression == ""
+
+def verify_plant_base_attribute(attribute: AttributeBase, path: str, name: str):
+    assert attribute.path == path
+    assert attribute.name == name
+    assert attribute.definition.path == "Repository/SimpleThermalTestRepository/PlantElementType/" + name
+    assert attribute.definition.description == ""
+    assert len(attribute.definition.tags) == 0
+    assert attribute.definition.namespace == "SimpleThermalTestRepository"
+    assert attribute.definition.value_type == "RatingCurveAttributeDefinition"


### PR DESCRIPTION
And switch to Mesh 2.5.2.33

The switch to Mesh 2.5.2.33 caused one test to fail (because we introduced a RatingCurveAttribute in the SimpleThermalModel) it was easier to fix it by adding implementation for handling RatingCurveAttribute.