### PR TITLE
Update protobuf dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 python = "^3.7.1" #pandas require python 3.7.1 or above
 grpcio = "^1.37.0"
 pyarrow = "^4.0.1"
-protobuf = "^3.17.3"
+protobuf = "^3.20.1"
 winkerberos = { version = "^0.8.0", markers = "sys_platform == 'win32'" }
 kerberos = { version = "^1.3.1", markers = "sys_platform == 'linux'" }
 python-dateutil = "^2.8.2"

--- a/src/volue/mesh/_attribute.py
+++ b/src/volue/mesh/_attribute.py
@@ -39,7 +39,7 @@ def _get_attribute_value(proto_attribute_value: core_pb2.AttributeValue):
 
     if type(proto_value) is timestamp_pb2.Timestamp:
         # time zone aware datetime as UTC
-        proto_value = proto_value.ToDatetime().replace(tzinfo=tz.UTC)
+        proto_value = proto_value.ToDatetime(tz.UTC)
 
     return proto_value
 

--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -1090,7 +1090,7 @@ class Session(abc.ABC):
         # https://developers.google.com/protocol-buffers/docs/reference/python-generated#keyword-conflicts
         yield [RatingCurveVersion(
             x_range_from=proto_version.x_range_from,
-            valid_from_time=getattr(proto_version, "from").ToDatetime().replace(tzinfo=dateutil.tz.UTC),
+            valid_from_time=getattr(proto_version, "from").ToDatetime(dateutil.tz.UTC),
             x_value_segments=[RatingCurveSegment(
                 proto_segment.x_range_until,
                 proto_segment.factor_a,


### PR DESCRIPTION
Up till now the minimal supported version of protobuf was 3.17.3.
However in one place we used a functionality introduced in 3.20, i.e.:

"Timestamp.ToDatetime() now accepts an optional tzinfo parameter. If
specified, the function returns a timezone-aware datetime in the given time
zone. If omitted or None, the function returns a timezone-naive UTC datetime
(as previously)."[^1]

That functionality is not critical as it is really easy to replace with other approach, but updating to latest protobuf seems to be better solution. Switch to latest protobuf and update other places in our code to use this functionality to be consistent.

[^1]: Official release notes: https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0