### PR TITLE
How about an auto formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pytest-asyncio = "^0.15.1"
 pandas = "^1.3.4"
 sphinx_copybutton = ">=0.4.0"
 pylint = "^2.12.2"
+black = "^22.6.0"
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Simple way for writing consistent and PEP 8 compliant code.
I suggest using one of the most popular auto formatters: `black`. Other options are e.g.: `yapf` or `autopep8`.

Next thing could be `isort`.