### PR TITLE
Remove RatingCurveAttribute

### DIFF
--- a/docs/source/mesh_modelling.rst
+++ b/docs/source/mesh_modelling.rst
@@ -201,18 +201,6 @@ readability. Here is a list of all attribute types currently supported:
   Definition value types are "ElementAttributeDefinition" for singular value or
   "ElementCollectionAttributeDefinition" for collection of values.
 
-* **Rating curve attributes** - Mesh rating curve attribute contains a set of
-  :doc:`rating curve versions <mesh_rating_curve>`. 
-  Because the rating curve versions can potentially contain large amounts of
-  data, specialized methods exist to handle those.
-  See `Session.get_rating_curve_versions` and `Session.update_rating_curve_versions`.
-
-  As a result the Python's **rating curve attribute** contains only limited data,
-  like `definition_name`.
-
-  Definition value type is "RatingCurveAttributeDefinition". Rating curve attributes
-  have only singular value, there is no collection of values.
-
 
 .. note::
 

--- a/src/volue/mesh/__init__.py
+++ b/src/volue/mesh/__init__.py
@@ -5,7 +5,7 @@ Client library for Volue Energy's Mesh software.
 from ._authentication import Authentication
 from ._timeseries import Timeseries
 from ._timeseries_resource import TimeseriesResource
-from ._attribute import AttributeBase, RatingCurveAttribute, TimeseriesAttribute
+from ._attribute import AttributeBase, TimeseriesAttribute
 from ._object import Object
 from ._common import (AttributesFilter, UserIdentity, VersionInfo,
                       XyCurve, XySet, RatingCurveSegment, RatingCurveVersion)
@@ -20,7 +20,6 @@ __all__ = [
     'Credentials',
     'Connection',
     'AttributeBase',
-    'RatingCurveAttribute',
     'TimeseriesAttribute',
     'Object',
     'Timeseries',

--- a/src/volue/mesh/_attribute.py
+++ b/src/volue/mesh/_attribute.py
@@ -68,18 +68,22 @@ def _from_proto_attribute(proto_attribute: core_pb2.Attribute) -> Type[Attribute
 
     if attribute_value_type == 'timeseries_value':
         attribute = TimeseriesAttribute._from_proto_attribute(proto_attribute)
-    elif attribute_value_type == 'rating_curve_value':
-        attribute = RatingCurveAttribute._from_proto_attribute(proto_attribute)
     # Relationship attribute is a bit special.
     # It does not have a value, only definition.
     # It will be treated as generic AttributeBase if
     # definition is not a part of the proto message.
     elif attribute_value_type is None and attribute_definition_type == "relationship_definition":
         attribute = RelationshipAttribute._from_proto_attribute(proto_attribute)
-    elif attribute_value_type is None:
-        attribute = AttributeBase._from_proto_attribute(proto_attribute)
-    else:
+    elif attribute_value_type in (
+        "int_value",
+        "double_value",
+        "boolean_value",
+        "string_value",
+        "utc_time_value",
+    ):
         attribute = SimpleAttribute._from_proto_attribute(proto_attribute)
+    else:
+        attribute = AttributeBase._from_proto_attribute(proto_attribute)
 
     return attribute
 
@@ -427,75 +431,5 @@ class TimeseriesAttribute(AttributeBase):
                 f"\t template_expression: {self.definition.template_expression}\n"
                 f"\t unit_of_measurement: {self.definition.unit_of_measurement}"
             )
-
-        return message
-
-
-@dataclass
-class RatingCurveAttribute(AttributeBase):
-    """Represents rating curve Mesh Attribute.
-
-    A rating curve is used to convert water level in river measurements in
-    a watercourse to discharge. There is a math formula that does this
-    conversion. Depending on the water level the formula has different factors.
-    To reflect that a rating curve segment concept is introduced.
-
-    Moreover rating curves can change over time because of for example changes
-    in a river due to erosion and sedimentation. Such changes affect the
-    discharge function and the function equation factors need to be adjusted.
-    To reflect that the rating curve segments in Mesh are grouped into
-    rating curve versions.
-
-    Refer to documentation for more details about rating curves:
-    :doc:`Mesh rating curve <mesh_rating_curve>`.
-
-    Because the rating curve can potentially contain large amounts of data,
-    specialized methods exist to handle those values.
-    See `Session.get_rating_curve_versions` and `Session.update_rating_curve_versions`.
-
-    Refer to documentation for more details about attributes:
-    :ref:`Mesh attribute <mesh_attribute>`.
-    """
-
-    
-    """
-    Versions are kept in a RatingCurveDefinition structure.
-    This is the name of this structure, it is/might be used
-    by UI applications communicating with Mesh.
-    Note: It is kept on the model level (not model definition),
-          so this is not the same as the name of definition
-          from AttributeDefinition.
-    """
-    definition_name: str = None
-
-    @classmethod
-    def _from_proto_attribute(cls, proto_attribute: core_pb2.Attribute):
-        """Create a `RatingCurveAttribute` from protobuf Mesh Attribute.
-
-        Args:
-            proto_attribute: protobuf Attribute returned from the gRPC methods.
-
-        Raises:
-            TypeError: Error message raised if collection of rating curve
-                attributes is passed as input.
-        """
-        attribute = cls()
-        super()._init_from_proto_attribute(attribute, proto_attribute)
-
-        if proto_attribute.HasField('singular_value'):
-            proto_value = proto_attribute.singular_value.rating_curve_value
-            attribute.definition_name = proto_value.definition_name
-        elif len(proto_attribute.collection_values) > 0:
-            raise TypeError('rating curve collection attribute is not supported')
-
-        return attribute
-
-    def __str__(self) -> str:
-        base_message = super()._get_string_representation()
-        message = (
-            f"RatingCurveAttribute:\n"
-            f"\t {base_message}\n"
-            f"\t definition_name: {self.definition_name}"
-        )
 
         return message

--- a/src/volue/mesh/examples/working_with_rating_curves.py
+++ b/src/volue/mesh/examples/working_with_rating_curves.py
@@ -16,11 +16,6 @@ def main(address, port, tls_root_cert):
 
         # First read the attribute using `get_attribute`.
         # We can get standard information like name, ID, tags, etc.
-        # Only rating curve attribute specific value is the
-        # `definition_name`, which is the name of a RatingCurveDefinition
-        # structure, where all rating curve versions are stored. It is
-        # defined on the model level (not model definition), so this is not
-        # the same as the name of definition from AttributeDefinition.
         rating_curve_attribute = session.get_attribute(
             rating_curve_attribute_path, full_attribute_info=True)
         print(f"Basic information about the rating curve attribute: {rating_curve_attribute}\n")

--- a/src/volue/mesh/tests/test_aio_connection.py
+++ b/src/volue/mesh/tests/test_aio_connection.py
@@ -1117,7 +1117,6 @@ async def test_get_rating_curve_attribute(async_session):
     verify_plant_base_attribute(attribute, path=attribute_path, name=attribute_name)
     assert attribute.definition.minimum_cardinality == 1
     assert attribute.definition.maximum_cardinality == 1
-    assert attribute.definition_name == "TestRatingCurveDefinition"
 
 
 @pytest.mark.asyncio

--- a/src/volue/mesh/tests/test_connection.py
+++ b/src/volue/mesh/tests/test_connection.py
@@ -1092,7 +1092,6 @@ def test_get_rating_curve_attribute(session):
     verify_plant_base_attribute(attribute, path=attribute_path, name=attribute_name)
     assert attribute.definition.minimum_cardinality == 1
     assert attribute.definition.maximum_cardinality == 1
-    assert attribute.definition_name == "TestRatingCurveDefinition"
 
 
 @pytest.mark.database

--- a/src/volue/mesh/tests/test_utilities/utilities.py
+++ b/src/volue/mesh/tests/test_utilities/utilities.py
@@ -249,4 +249,3 @@ def verify_plant_base_attribute(attribute: AttributeBase, path: str, name: str):
     assert attribute.definition.description == ""
     assert len(attribute.definition.tags) == 0
     assert attribute.definition.namespace == "SimpleThermalTestRepository"
-    assert attribute.definition.value_type == "RatingCurveAttributeDefinition"

--- a/src/volue/mesh/use_cases/use_cases.py
+++ b/src/volue/mesh/use_cases/use_cases.py
@@ -1206,11 +1206,6 @@ def use_case_21():
 
             # First read the attribute using `get_attribute`.
             # We can get standard information like name, ID, tags, etc.
-            # The only rating curve attribute specific value is the
-            # `definition_name`, which is the name of a RatingCurveDefinition
-            # structure, where all rating curve versions are stored. It is
-            # defined on the model level (not model definition), so this is not
-            # the same as the name of definition from AttributeDefinition.
             rating_curve_attribute = session.get_attribute(
                 attribute_path, full_attribute_info=True)
             print(f"Basic information about the rating curve attribute:\n{rating_curve_attribute}\n")


### PR DESCRIPTION
Rating curve definition history has come full circle. This PR as a follow-up from the https://github.com/PowelAS/sme-mesh-python/pull/259#issuecomment-1177654358. The final decision was to remove the `definition_name` completely. Because `RatingCurveAttribute`'s only job was to expose the `definition_name` it is removed as well.

The proto `RatingCurveAttributeValue` will be removed in Mesh 2.6 as it is not used anywhere else.
