### PR TITLE
Extend and refactor TimeseriesResource tests

### DIFF
--- a/src/volue/mesh/_timeseries_resource.py
+++ b/src/volue/mesh/_timeseries_resource.py
@@ -5,6 +5,7 @@ Functionality for working with time series resources.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 from volue.mesh import Timeseries
 from volue.mesh._common import _from_proto_curve_type, _from_proto_resolution
@@ -22,7 +23,7 @@ class TimeseriesResource:
     curve_type: Timeseries.Curve
     resolution: Timeseries.Resolution
     unit_of_measurement: str
-    virtual_timeseries_expression: str
+    virtual_timeseries_expression: Optional[str] = None
 
     @classmethod
     def _from_proto_timeseries_resource(

--- a/src/volue/mesh/tests/test_aio_connection.py
+++ b/src/volue/mesh/tests/test_aio_connection.py
@@ -183,59 +183,6 @@ async def test_write_timeseries_points_with_different_pyarrow_table_datetime_tim
 
 @pytest.mark.asyncio
 @pytest.mark.database
-async def test_get_timeseries_resource(async_session):
-    """Check that time series resource can be retrieved."""
-    physical_timeseries = get_physical_timeseries()
-    virtual_timeseries = get_virtual_timeseries()
-
-    test_cases = [physical_timeseries, virtual_timeseries]
-
-    for test_case in test_cases:
-        timeseries_info = await async_session.get_timeseries_resource_info(
-            timeseries_key=test_case.timeseries_key)
-        assert isinstance(timeseries_info, TimeseriesResource)
-        assert timeseries_info.timeseries_key == test_case.timeseries_key
-        assert timeseries_info.path == test_case.path
-        assert timeseries_info.name == test_case.name
-        assert timeseries_info.temporary == test_case.temporary
-        assert timeseries_info.curve_type == test_case.curve_type
-        assert timeseries_info.resolution == test_case.resolution
-        assert timeseries_info.unit_of_measurement == test_case.unit_of_measurement
-        #assert timeseries_info.virtual_timeseries_expression == test_case.virtual_timeseries_expression
-
-
-@pytest.mark.asyncio
-@pytest.mark.database
-async def test_update_timeseries_resource(async_session):
-    """Check that time series resource can be updated."""
-    new_curve_type = Timeseries.Curve.STAIRCASESTARTOFSTEP
-    new_unit_of_measurement = "Unit1"
-
-    timeseries = get_physical_timeseries()
-
-    test_id = {"timeseries_key": timeseries.timeseries_key}
-    test_new_curve_type = {"new_curve_type": new_curve_type}
-    test_new_unit_of_measurement = {"new_unit_of_measurement": new_unit_of_measurement}
-    test_cases = [
-        {**test_id, **test_new_curve_type},
-        {**test_id, **test_new_unit_of_measurement},
-        {**test_id, **test_new_curve_type, **test_new_unit_of_measurement}
-    ]
-
-    for test_case in test_cases:
-        await async_session.update_timeseries_resource_info(**test_case)
-        timeseries_info = await async_session.get_timeseries_resource_info(**test_id)
-
-        if "new_curve_type" in test_case:
-            assert timeseries_info.curve_type == new_curve_type
-        if "new_unit_of_measurement" in test_case:
-            assert timeseries_info.unit_of_measurement == new_unit_of_measurement
-
-        await async_session.rollback()
-
-
-@pytest.mark.asyncio
-@pytest.mark.database
 async def test_write_timeseries_points_using_timskey_async(async_session):
     """Check that time series can be written to the server using timskey."""
     ts_entry, start_time, end_time, modified_table, _ = get_timeseries_2()

--- a/src/volue/mesh/tests/test_connection.py
+++ b/src/volue/mesh/tests/test_connection.py
@@ -178,59 +178,6 @@ def test_write_timeseries_points_with_different_pyarrow_table_datetime_timezones
 
 
 @pytest.mark.database
-def test_get_timeseries_resource(session):
-    """Check that time series resource can be retrieved."""
-
-    physical_timeseries = get_physical_timeseries()
-    virtual_timeseries = get_virtual_timeseries()
-
-    test_cases = [physical_timeseries, virtual_timeseries]
-
-    for test_case in test_cases:
-        timeseries_info = session.get_timeseries_resource_info(
-            timeseries_key=test_case.timeseries_key)
-        assert isinstance(timeseries_info, TimeseriesResource)
-        assert timeseries_info.timeseries_key == test_case.timeseries_key
-        assert timeseries_info.path == test_case.path
-        assert timeseries_info.name == test_case.name
-        assert timeseries_info.temporary == test_case.temporary
-        assert timeseries_info.curve_type == test_case.curve_type
-        assert timeseries_info.resolution == test_case.resolution
-        assert timeseries_info.unit_of_measurement == test_case.unit_of_measurement
-        #assert timeseries_info.virtual_timeseries_expression == test_case.virtual_timeseries_expression
-
-
-@pytest.mark.database
-def test_update_timeseries_resource(session):
-    """Check that time series resource can be updated."""
-
-    new_curve_type = Timeseries.Curve.STAIRCASESTARTOFSTEP
-    new_unit_of_measurement = "Unit1"
-
-    timeseries = get_physical_timeseries()
-
-    test_id = {"timeseries_key": timeseries.timeseries_key}
-    test_new_curve_type = {"new_curve_type": new_curve_type}
-    test_new_unit_of_measurement = {"new_unit_of_measurement": new_unit_of_measurement}
-    test_cases = [
-        {**test_id, **test_new_curve_type},
-        {**test_id, **test_new_unit_of_measurement},
-        {**test_id, **test_new_curve_type, **test_new_unit_of_measurement}
-    ]
-
-    for test_case in test_cases:
-        session.update_timeseries_resource_info(**test_case)
-        timeseries_info = session.get_timeseries_resource_info(**test_id)
-
-        if "new_curve_type" in test_case:
-            assert timeseries_info.curve_type == new_curve_type
-        if "new_unit_of_measurement" in test_case:
-            assert timeseries_info.unit_of_measurement == new_unit_of_measurement
-
-        session.rollback()
-
-
-@pytest.mark.database
 def test_write_timeseries_points_using_timskey(session):
     """Check that time series can be written to the server using timskey."""
 

--- a/src/volue/mesh/tests/test_timeseries_resource.py
+++ b/src/volue/mesh/tests/test_timeseries_resource.py
@@ -1,0 +1,143 @@
+"""
+Tests for volue.mesh.TimeseriesResource
+"""
+
+import sys
+
+import grpc
+import pytest
+
+from volue.mesh import Timeseries, TimeseriesResource
+
+
+def get_physical_timeseries():
+    """
+    Physical time series from SimpleThermalModel test model.
+    """
+    ts_name = "chimney2TimeSeriesRaw"
+    test_timeseries = TimeseriesResource(
+        timeseries_key=3,
+        temporary=False,
+        curve_type=Timeseries.Curve.PIECEWISELINEAR,
+        resolution=Timeseries.Resolution.HOUR,
+        unit_of_measurement="Unit2",
+        path=f"Resource/SimpleThermalTestResourceCatalog/{ts_name}",
+        name=ts_name,
+    )
+    return test_timeseries
+
+
+def get_virtual_timeseries():
+    """
+    Virtual time series from SimpleThermalModel test model.
+    """
+    ts_name = "simpleVtsTimeseries"
+    test_timeseries = TimeseriesResource(
+        timeseries_key=4,
+        temporary=False,
+        curve_type=Timeseries.Curve.PIECEWISELINEAR,
+        resolution=Timeseries.Resolution.HOUR,
+        unit_of_measurement="",
+        path=f"Resource/SimpleThermalTestResourceCatalog/{ts_name}",
+        name=ts_name,
+        virtual_timeseries_expression="## = 5\n",
+    )
+    return test_timeseries
+
+
+@pytest.mark.database
+@pytest.mark.parametrize(
+    "timeseries", [get_virtual_timeseries(), get_physical_timeseries()]
+)
+def test_get_timeseries_resource(session, timeseries):
+    """Check that time series resource can be retrieved."""
+
+    timeseries_info = session.get_timeseries_resource_info(
+        timeseries_key=timeseries.timeseries_key
+    )
+    assert isinstance(timeseries_info, TimeseriesResource)
+    assert timeseries_info.timeseries_key == timeseries.timeseries_key
+    assert timeseries_info.path == timeseries.path
+    assert timeseries_info.name == timeseries.name
+    assert timeseries_info.temporary == timeseries.temporary
+    assert timeseries_info.curve_type == timeseries.curve_type
+    assert timeseries_info.resolution == timeseries.resolution
+    assert timeseries_info.unit_of_measurement == timeseries.unit_of_measurement
+    # TODO: Enable once SimpleThermalModel could be populated with VTS
+    #      expressions (serialization version needs to be at least 24).
+    # if timeseries.virtual_timeseries_expression is None:
+    #     assert timeseries_info.virtual_timeseries_expression == ""
+    # else:
+    #     assert timeseries_info.virtual_timeseries_expression == timeseries.virtual_timeseries_expression
+
+
+@pytest.mark.database
+@pytest.mark.parametrize(
+    "timeseries_key",
+    [get_virtual_timeseries().timeseries_key, get_physical_timeseries().timeseries_key],
+)
+@pytest.mark.parametrize(
+    "new_curve_type, new_unit_of_measurement",
+    [
+        (Timeseries.Curve.STAIRCASESTARTOFSTEP, None),
+        (None, "Unit1"),
+        (Timeseries.Curve.PIECEWISELINEAR, "Unit2"),
+    ],
+)
+def test_update_timeseries_resource(
+    session, timeseries_key, new_curve_type, new_unit_of_measurement
+):
+    """Check that time series resource can be updated."""
+    session.update_timeseries_resource_info(
+        timeseries_key, new_curve_type, new_unit_of_measurement
+    )
+    timeseries_info = session.get_timeseries_resource_info(timeseries_key)
+
+    if new_curve_type is not None:
+        assert timeseries_info.curve_type == new_curve_type
+    if new_unit_of_measurement is not None:
+        assert timeseries_info.unit_of_measurement == new_unit_of_measurement
+
+
+@pytest.mark.database
+def test_update_timeseries_resource_with_non_existing_unit_of_measurement(session):
+    """
+    Check that 'update_timeseries_resource_info' with non existing unit of
+    measurement will throw.
+    """
+
+    timeseries_key = get_physical_timeseries().timeseries_key
+    non_existing_unit_of_measurement = "no_such_unit"
+
+    original_unit_of_measurement = session.get_timeseries_resource_info(
+        timeseries_key
+    ).unit_of_measurement
+
+    with pytest.raises(grpc.RpcError, match="Invalid unit of measurement provided"):
+        session.update_timeseries_resource_info(
+            timeseries_key, new_unit_of_measurement=non_existing_unit_of_measurement
+        )
+
+    timeseries_resource = session.get_timeseries_resource_info(timeseries_key)
+    assert timeseries_resource.unit_of_measurement == original_unit_of_measurement
+
+
+@pytest.mark.asyncio
+@pytest.mark.database
+async def test_timeseries_resource_async(async_session):
+    """For async run the simplest test, implementation is the same."""
+
+    timeseries_key = get_physical_timeseries().timeseries_key
+    new_curve_type = Timeseries.Curve.STAIRCASE
+    new_unit_of_measurement = "Unit1"
+
+    await async_session.update_timeseries_resource_info(
+        timeseries_key, new_curve_type, new_unit_of_measurement
+    )
+    timeseries_info = await async_session.get_timeseries_resource_info(timeseries_key)
+    assert timeseries_info.curve_type == new_curve_type
+    assert timeseries_info.unit_of_measurement == new_unit_of_measurement
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
* Extract `TimeseriesResource` related tests to one file
* Parametrize tests
* Add negative case for update operation
* Make `virtual_timeseries_expression` field optional - not every time series resource is a virtual time series