### PR TITLE
Improve examples for reading and writing time series

### DIFF
--- a/src/volue/mesh/examples/read_timeseries_points.py
+++ b/src/volue/mesh/examples/read_timeseries_points.py
@@ -1,44 +1,54 @@
-"""
-Example showing how to read time series
-"""
-
 import uuid
 from datetime import datetime
+
 from volue.mesh import Connection
 from volue.mesh.examples import _get_connection_info
 
 
 def read_timeseries_points(session: Connection.Session):
-    """Showing how to read timeseries points."""
+    """Showing how to read time series points."""
 
-    # Define the timeseries identifiers
-    timeseries_full_name = (
-        "Resource/SimpleThermalTestResourceCatalog/chimney2TimeSeriesRaw"
-    )
-    timeseries_id = uuid.UUID("00000003-0003-0000-0000-000000000000")
+    # Define the time series identifier, it can be:
+    # - time series key of a physical time series
+    # - path of a time series attribute that is connected to a physical time series
+    # - ID of a time series attribute that is connected to a physical time series
+    timeseries_key = 3
+    timeseries_attribute_path = "Model/SimpleThermalTestModel/ThermalComponent/SomePowerPlant1/SomePowerPlantChimney2.TsRawAtt"
+    timeseries_attribute_id = uuid.UUID("e5df77a9-8b60-4b0a-aa1b-3c3957c538a0")
 
-    # Defining a time interval to read timeseries from.
+    # Defining a time interval to read time series from.
     # If no time zone is provided then it will be treated as UTC.
     start = datetime(2016, 1, 1, 6, 0, 0)
     end = datetime(2016, 1, 1, 8, 0, 0)
 
-    # Send request to read timeseries based on path
+    # Send request to read time series based on time series key.
     timeseries = session.read_timeseries_points(
-        target=timeseries_full_name, start_time=start, end_time=end
+        target=timeseries_key, start_time=start, end_time=end
     )
-    print(f"Read {timeseries.number_of_points} points")
+    print(f"Read {timeseries.number_of_points} points using time series key.")
+    print(timeseries.arrow_table.to_pandas())
 
-    # OR
-
-    # Send request to read timeseries based on guid
+    # Send requests to read time series based on time series attribute path.
     timeseries = session.read_timeseries_points(
-        target=timeseries_id, start_time=start, end_time=end
+        target=timeseries_attribute_path, start_time=start, end_time=end
     )
-    print(f"Read {timeseries.number_of_points} points")
+    print(
+        f"Read {timeseries.number_of_points} points using time series attribute path."
+    )
+    print(timeseries.arrow_table.to_pandas())
+
+    # Send requests to read time series based on time series attribute ID.
+    # Attribute IDs are auto-generated when an object is created.
+    # That is why we can't use any fixed ID in this example and the code is commented out.
+    # timeseries = session.read_timeseries_points(
+    #     target=timeseries_attribute_id, start_time=start, end_time=end
+    # )
+    # print(f"Read {timeseries.number_of_points} points using time series attribute ID.")
+    # print(timeseries.arrow_table.to_pandas())
 
 
 def main(address, port, root_pem_certificate):
-    """Showing how to get timeseries points."""
+    """Showing how to get time series points."""
     connection = Connection(address, port, root_pem_certificate)
 
     with connection.create_session() as session:

--- a/src/volue/mesh/examples/read_timeseries_points_async.py
+++ b/src/volue/mesh/examples/read_timeseries_points_async.py
@@ -7,38 +7,49 @@ from volue.mesh.examples import _get_connection_info
 
 
 async def read_timeseries_points_async(session: Connection.Session):
-    """Showing how to read timeseries points."""
+    """Showing how to read time series points."""
 
-    # Define the timeseries identifiers
-    timeseries_full_name = (
-        "Resource/SimpleThermalTestResourceCatalog/chimney2TimeSeriesRaw"
-    )
-    timeseries_id = uuid.UUID("00000003-0003-0000-0000-000000000000")
+    # Define the time series identifier, it can be:
+    # - time series key of a physical time series
+    # - path of a time series attribute that is connected to a physical time series
+    # - ID of a time series attribute that is connected to a physical time series
+    timeseries_key = 3
+    timeseries_attribute_path = "Model/SimpleThermalTestModel/ThermalComponent/SomePowerPlant1/SomePowerPlantChimney2.TsRawAtt"
+    timeseries_attribute_id = uuid.UUID("e5df77a9-8b60-4b0a-aa1b-3c3957c538a0")
 
-    # Defining a time interval to read timeseries from.
+    # Defining a time interval to read time series from.
     # If no time zone is provided then it will be treated as UTC.
     start = datetime(2016, 1, 1, 6, 0, 0)
     end = datetime(2016, 1, 1, 8, 0, 0)
 
-    # Indicate that these two functions can be run concurrently
-    full_name_timeseries, id_timeseries = await asyncio.gather(
-        session.read_timeseries_points(
-            target=timeseries_full_name, start_time=start, end_time=end
-        ),
-        session.read_timeseries_points(
-            target=timeseries_id, start_time=start, end_time=end
-        ),
+    # Send request to read time series based on time series key.
+    timeseries = await session.read_timeseries_points(
+        target=timeseries_key, start_time=start, end_time=end
+    )
+    print(f"Read {timeseries.number_of_points} points using time series key.")
+    print(timeseries.arrow_table.to_pandas())
+
+    # Send requests to read time series based on time series attribute path.
+    timeseries = await session.read_timeseries_points(
+        target=timeseries_attribute_path, start_time=start, end_time=end
     )
     print(
-        f"Timeseries found using id contains {full_name_timeseries.number_of_points}."
+        f"Read {timeseries.number_of_points} points using time series attribute path."
     )
-    print(
-        f"Timeseries found using full name contains {id_timeseries.number_of_points}."
-    )
+    print(timeseries.arrow_table.to_pandas())
+
+    # Send requests to read time series based on time series attribute ID.
+    # Attribute IDs are auto-generated when an object is created.
+    # That is why we can't use any fixed ID in this example and the code is commented out.
+    # timeseries = await session.read_timeseries_points(
+    #     target=timeseries_attribute_id, start_time=start, end_time=end
+    # )
+    # print(f"Read {timeseries.number_of_points} points using time series attribute ID.")
+    # print(timeseries.arrow_table.to_pandas())
 
 
 async def main(address, port, root_pem_certificate):
-    """Showing how to get timeseries points asynchronously."""
+    """Showing how to get time series points asynchronously."""
     connection = Connection(address, port, root_pem_certificate)
 
     async with connection.create_session() as session:

--- a/src/volue/mesh/examples/write_timeseries_points.py
+++ b/src/volue/mesh/examples/write_timeseries_points.py
@@ -1,19 +1,24 @@
 import uuid
+from datetime import datetime
+
 import pyarrow as pa
-from datetime import datetime, timezone
+
 from volue.mesh import Connection, Timeseries
 from volue.mesh.examples import _get_connection_info
 
 
 def write_timeseries_points(session: Connection.Session):
-    """Showing how to write timeseries points."""
+    """Showing how to write time series points."""
 
-    # Define the timeseries identifiers
-    timeseries_full_name = (
-        "Resource/SimpleThermalTestResourceCatalog/chimney2TimeSeriesRaw"
-    )
+    # Define the time series identifier, it can be:
+    # - time series key of a physical time series
+    # - path of a time series attribute that is connected to a physical time series
+    # - ID of a time series attribute that is connected to a physical time series
+    timeseries_key = 3
+    timeseries_attribute_path = "Model/SimpleThermalTestModel/ThermalComponent/SomePowerPlant1/SomePowerPlantChimney2.TsRawAtt"
+    timeseries_attribute_id = uuid.UUID("e5df77a9-8b60-4b0a-aa1b-3c3957c538a0")
 
-    # Defining the data we want to write
+    # Defining the data we want to write.
     # Mesh data is organized as an Arrow table with the following schema:
     # utc_time - [pa.timestamp('ms')] as a UTC Unix timestamp expressed in milliseconds
     # flags - [pa.uint32]
@@ -23,24 +28,37 @@ def write_timeseries_points(session: Connection.Session):
         pa.array(
             [datetime(2016, 1, 1, 1), datetime(2016, 1, 1, 2), datetime(2016, 1, 1, 3)]
         ),
-        pa.array([0, 0, 0]),
+        pa.array([Timeseries.PointFlags.OK.value] * 3),
         pa.array([0.0, 10.0, 1000.0]),
     ]
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
-    timeseries = Timeseries(table=table, full_name=timeseries_full_name)
 
-    # Send request to write timeseries based on timskey
+    # Send requests to write time series based on timskey.
+    timeseries = Timeseries(table=table, timskey=timeseries_key)
     session.write_timeseries_points(timeseries=timeseries)
+    print("Time series points written using time series key.")
 
-    # Commit the changes to the database
+    # Send requests to write time series based on time series attribute path/full_name.
+    timeseries = Timeseries(table=table, full_name=timeseries_attribute_path)
+    session.write_timeseries_points(timeseries=timeseries)
+    print("Time series points written using time series attribute path.")
+
+    # Send requests to write time series based on time series attribute ID.
+    # Attribute IDs are auto-generated when an object is created.
+    # That is why we can't use any fixed ID in this example and the code is commented out.
+    # timeseries = Timeseries(table=table, uuid_id=timeseries_attribute_id)
+    # session.write_timeseries_points(timeseries=timeseries)
+    # print("Time series points written using time series attribute ID.")
+
+    # Commit the changes to the database.
     # session.commit()
 
-    # Or discard changes
+    # Or discard changes.
     session.rollback()
 
 
 def main(address, port, root_pem_certificate):
-    """Showing how to write timeseries points."""
+    """Showing how to write time series points."""
     connection = Connection(address, port, root_pem_certificate)
 
     with connection.create_session() as session:

--- a/src/volue/mesh/examples/write_timeseries_points_async.py
+++ b/src/volue/mesh/examples/write_timeseries_points_async.py
@@ -1,20 +1,26 @@
 import asyncio
+import uuid
+from datetime import datetime
+
 import pyarrow as pa
-from datetime import datetime, timezone
-from volue.mesh.aio import Connection
+
 from volue.mesh import Timeseries
+from volue.mesh.aio import Connection
 from volue.mesh.examples import _get_connection_info
 
 
 async def write_timeseries_points(session: Connection.Session):
     """Showing how to write timeseries points."""
 
-    # Define the timeseries identifiers
-    timeseries_full_name = (
-        "Resource/SimpleThermalTestResourceCatalog/chimney2TimeSeriesRaw"
-    )
+    # Define the time series identifier, it can be:
+    # - time series key of a physical time series
+    # - path of a time series attribute that is connected to a physical time series
+    # - ID of a time series attribute that is connected to a physical time series
+    timeseries_key = 3
+    timeseries_attribute_path = "Model/SimpleThermalTestModel/ThermalComponent/SomePowerPlant1/SomePowerPlantChimney2.TsRawAtt"
+    timeseries_attribute_id = uuid.UUID("e5df77a9-8b60-4b0a-aa1b-3c3957c538a0")
 
-    # Defining the data we want to write
+    # Defining the data we want to write.
     # Mesh data is organized as an Arrow table with the following schema:
     # utc_time - [pa.timestamp('ms')] as a UTC Unix timestamp expressed in milliseconds
     # flags - [pa.uint32]
@@ -24,19 +30,32 @@ async def write_timeseries_points(session: Connection.Session):
         pa.array(
             [datetime(2016, 1, 1, 1), datetime(2016, 1, 1, 2), datetime(2016, 1, 1, 3)]
         ),
-        pa.array([0, 0, 0]),
+        pa.array([Timeseries.PointFlags.OK.value] * 3),
         pa.array([0.0, 10.0, 1000.0]),
     ]
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
-    timeseries = Timeseries(table=table, full_name=timeseries_full_name)
 
-    # Send request to write timeseries based on timskey
+    # Send requests to write time series based on timskey.
+    timeseries = Timeseries(table=table, timskey=timeseries_key)
     await session.write_timeseries_points(timeseries=timeseries)
+    print("Time series points written using time series key.")
 
-    # Commit the changes to the database
+    # Send requests to write time series based on time series attribute path/full_name.
+    timeseries = Timeseries(table=table, full_name=timeseries_attribute_path)
+    await session.write_timeseries_points(timeseries=timeseries)
+    print("Time series points written using time series attribute path.")
+
+    # Send requests to write time series based on time series attribute ID.
+    # Attribute IDs are auto-generated when an object is created.
+    # That is why we can't use any fixed ID in this example and the code is commented out.
+    # timeseries = Timeseries(table=table, uuid_id=timeseries_attribute_id)
+    # await session.write_timeseries_points(timeseries=timeseries)
+    # print("Time series points written using time series attribute ID.")
+
+    # Commit the changes to the database.
     # await session.commit()
 
-    # Or discard changes
+    # Or discard changes.
     await session.rollback()
 
 


### PR DESCRIPTION
* Show and describe all 3 possible targets for reading and writing time series (time series key, time series attribute path and time series attribute ID).
* Use `Timeseries.PointsFlag.OK` instead of magic number 0