### PR TITLE
Use Mesh 2.6 release in GitHub actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -51,7 +51,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.5.2.33'
+          MESH_SERVICE_TAG: 'v2.6.0.5'
 
       - name: Run tests
         if: ${{ success() }}

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -39,7 +39,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.5.2.33'
+          MESH_SERVICE_TAG: 'v2.6.0.5'
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package


### PR DESCRIPTION
Mesh starting from 2.6 has different installation method - there is a script installer. Proper adjustments were done in https://github.com/PowelAS/sme-run-mesh-service/pull/9.