### PR TITLE
Update poetry installation step in pages github action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,8 +27,10 @@ jobs:
     - name: Install Linux Kerberos dependency
       run: sudo apt-get install -y libkrb5-dev
 
-    - name: Install Poetry
-      run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+    - name: Installing poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: '1.2.0'
 
     - name: Build and publish page
       run: |


### PR DESCRIPTION
`GitHub pages` action is failing on merging pull request. It is because of a new version of poetry that was released 6 days ago - [1.2.0](https://github.com/python-poetry/poetry/releases/tag/1.2.0). It no longer supports old installation method - update gh pages github action for correct installation of poetry.