### PR TITLE
Make github pages action work

### DIFF
--- a/.github/workflows/pages.sh
+++ b/.github/workflows/pages.sh
@@ -22,7 +22,6 @@ set -o nounset # Fail the script if an unset variable is used.
 repo_dir=$1
 pages_dir=$2
 
-source "$HOME/.poetry/env"
 pushd "$repo_dir"
 poetry install
 poetry run make -C "./docs" html

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,8 @@ jobs:
     - name: Install Linux Kerberos dependency
       run: sudo apt-get install -y libkrb5-dev
 
-    - name: Installing poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: '1.2.0'
+    - name: Install poetry
+      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
 
     - name: Build and publish page
       run: |


### PR DESCRIPTION
The `abatilo/actions-poetry` installed `poetry` via `pip` which had couldn't properly resolve dependencies in github action environment (Ubuntu 20.04, Python 3.8).

Using normal poetry's installer is resolving our dependencies correctly.