### PR TITLE
Remove test modules and examples from the documentation API section

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -24,33 +24,3 @@ volue.mesh.calc
 .. automodule:: volue.mesh.calc.history
 .. automodule:: volue.mesh.calc.statistical
 .. automodule:: volue.mesh.calc.transform
-
-
-volue.mesh.examples
-~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: volue.mesh.examples
-.. automodule:: volue.mesh.examples.connect_asynchronously
-.. automodule:: volue.mesh.examples.connect_synchronously
-.. automodule:: volue.mesh.examples.write_timeseries_points
-.. automodule:: volue.mesh.examples.write_timeseries_points_async
-.. automodule:: volue.mesh.examples.read_timeseries_points
-.. automodule:: volue.mesh.examples.read_timeseries_points_async
-.. automodule:: volue.mesh.examples.get_version
-.. automodule:: volue.mesh.examples.quickstart
-.. automodule:: volue.mesh.examples.timeseries_operations
-
-
-volue.mesh.tests
-~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: volue.mesh.tests
-.. automodule:: volue.mesh.tests.test_examples
-.. automodule:: volue.mesh.tests.test_session
-.. automodule:: volue.mesh.tests.test_timeseries
-.. automodule:: volue.mesh.tests.test_connection
-.. automodule:: volue.mesh.tests.test_aio_connection
-.. automodule:: volue.mesh.tests.test_authentication
-
-
-


### PR DESCRIPTION
I think only actual APIs should be there, not tests or examples.