### PR TITLE
Print more readable XY sets output in use case 20

### DIFF
--- a/src/volue/mesh/use_cases/use_cases.py
+++ b/src/volue/mesh/use_cases/use_cases.py
@@ -151,6 +151,22 @@ def get_object_information(object: Object):
     return message
 
 
+def get_versioned_xy_sets_information(xy_sets: List[XySet]):
+    """Create a printable message for versioned XY sets."""
+    message = ""
+
+    for i, xy_set in enumerate(xy_sets, 1):
+        message += (
+            f"XY set version {i} "
+            f"(valid from time: {xy_set.valid_from_time.astimezone(tz=LOCAL_TIME_ZONE):%Y-%m-%dT%H:%M:%S %Z}):\n"
+        )
+
+        for xy_curve in xy_set.xy_curves:
+            message += f"\t{xy_curve}\n"
+
+    return message
+
+
 def get_link_relation_attribute_information(
     attribute: LinkRelationAttribute, session: Connection.Session
 ):
@@ -1389,7 +1405,8 @@ def use_case_20():
             print("--------------------------------------------------------------")
 
             xy_sets = session.get_xy_sets(target, datetime.min, datetime.max)
-            print(f"Attribute value before update: {xy_sets}")
+            print(f"Attribute value before update:")
+            print(get_versioned_xy_sets_information(xy_sets))
 
             start_time = datetime(2022, 1, 1, tzinfo=LOCAL_TIME_ZONE)
             new_xy_set = XySet(
@@ -1399,7 +1416,8 @@ def use_case_20():
             session.update_xy_sets(target, start_time, datetime.max, [new_xy_set])
 
             xy_sets = session.get_xy_sets(target, datetime.min, datetime.max)
-            print(f"Attribute value after update: {xy_sets}")
+            print(f"Attribute value after update:")
+            print(get_versioned_xy_sets_information(xy_sets))
 
             # Commit changes
             if COMMIT_CHANGES:


### PR DESCRIPTION
As requested by @Vanndamen 

Output example:
```
XY set version 1 (valid from time: 2022-01-01T00:00:00 Central European Standard Time):
        XyCurve(z=0.0, xy=[(0.0, 0.0), (0.5, 0.0), (1.0, 0.0), (1.5, 0.0), (2.0, 0.0), (2.5, 0.0), (3.0, 0.0), (3.5, 0.0), (4.0, 0.057), (4.5, 0.0855), (5.0, 0.1133), (5.5, 0.1478), (6.0, 0.1943)])
XY set version 2 (valid from time: 2022-02-01T00:00:00 Central European Standard Time):
        XyCurve(z=0.0, xy=[(1.0, 15.0), (2.0, 30.0)])
        XyCurve(z=1.0, xy=[(11.0, 115.0), (21.0, 130.0)])
```