### PR TITLE
Update black auto-formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pytest-asyncio = "^0.19.0"
 pandas = "^1.3.4"
 sphinx_copybutton = ">=0.4.0"
 pylint = "^2.12.2"
-black = "^22.6.0"
+black = ">=23.1.0"
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -974,7 +974,6 @@ class Session(abc.ABC):
     def _prepare_get_attribute_request(
         self, target: Union[uuid.UUID, str, AttributeBase], full_attribute_info: bool
     ) -> core_pb2.GetAttributeRequest:
-
         attribute_view = (
             core_pb2.AttributeView.FULL
             if full_attribute_info
@@ -995,7 +994,6 @@ class Session(abc.ABC):
         query: str,
         full_attribute_info: bool,
     ) -> core_pb2.SearchAttributesRequest:
-
         attribute_view = (
             core_pb2.AttributeView.FULL
             if full_attribute_info
@@ -1016,7 +1014,6 @@ class Session(abc.ABC):
         target: Union[uuid.UUID, str, AttributeBase],
         value: SIMPLE_TYPE_OR_COLLECTION,
     ) -> core_pb2.UpdateSimpleAttributeRequest:
-
         request = core_pb2.UpdateSimpleAttributeRequest(
             session_id=_to_proto_guid(self.session_id),
             attribute_id=_to_proto_attribute_mesh_id(target),
@@ -1042,7 +1039,6 @@ class Session(abc.ABC):
         new_local_expression: Optional[str],
         new_timeseries_resource_key: Optional[int],
     ) -> core_pb2.UpdateTimeseriesAttributeRequest:
-
         request = core_pb2.UpdateTimeseriesAttributeRequest(
             session_id=_to_proto_guid(self.session_id),
             attribute_id=_to_proto_attribute_mesh_id(target),
@@ -1068,7 +1064,6 @@ class Session(abc.ABC):
         new_target_object_ids: List[uuid.UUID],
         append: bool,
     ) -> core_pb2.UpdateLinkRelationAttributeRequest:
-
         proto_target_object_ids = [
             _to_proto_guid(target_object_id)
             for target_object_id in new_target_object_ids
@@ -1089,7 +1084,6 @@ class Session(abc.ABC):
         end_time: datetime,
         new_versions: List[LinkRelationVersion],
     ) -> core_pb2.UpdateVersionedLinkRelationAttributeRequest:
-
         if start_time is None or end_time is None:
             raise TypeError("start_time and end_time must both have a value")
 
@@ -1120,7 +1114,6 @@ class Session(abc.ABC):
     def _to_proto_singular_attribute_value(
         self, v: SIMPLE_TYPE
     ) -> core_pb2.AttributeValue:
-
         att_value = core_pb2.AttributeValue()
         if type(v) is int:
             att_value.int_value = v
@@ -1166,7 +1159,6 @@ class Session(abc.ABC):
         new_curve_type: Optional[Timeseries.Curve],
         new_unit_of_measurement: Optional[str],
     ) -> core_pb2.UpdateTimeseriesResourceRequest:
-
         request = core_pb2.UpdateTimeseriesResourceRequest(
             session_id=_to_proto_guid(self.session_id),
             timeseries_resource_key=timeseries_key,
@@ -1242,7 +1234,6 @@ class Session(abc.ABC):
         end_time: datetime,
         new_versions: List[RatingCurveVersion],
     ) -> core_pb2.UpdateRatingCurveVersionsRequest:
-
         if start_time is None or end_time is None:
             raise TypeError("start_time and end_time must both have a value")
 

--- a/src/volue/mesh/examples/working_with_link_relations.py
+++ b/src/volue/mesh/examples/working_with_link_relations.py
@@ -197,10 +197,8 @@ def versioned_one_to_many_link_relation_example(session: Connection.Session):
 
 
 def main(address, port, tls_root_cert):
-
     connection = Connection(address, port, tls_root_cert)
     with connection.create_session() as session:
-
         one_to_one_link_relation_example(session)
         one_to_many_link_relation_example(session)
         versioned_one_to_one_link_relation_example(session)

--- a/src/volue/mesh/examples/working_with_model.py
+++ b/src/volue/mesh/examples/working_with_model.py
@@ -7,7 +7,6 @@ def main(address, port, tls_root_cert):
 
     connection = Connection(address, port, tls_root_cert)
     with connection.create_session() as session:
-
         # Root object has an ownership relation attribute that point to objects
         # of "PlantElementType" type. We want to add new object of this type.
         root_object = session.get_object(root_object_path, full_attribute_info=True)

--- a/src/volue/mesh/examples/working_with_rating_curves.py
+++ b/src/volue/mesh/examples/working_with_rating_curves.py
@@ -14,7 +14,6 @@ def main(address, port, tls_root_cert):
 
     connection = Connection(address, port, tls_root_cert)
     with connection.create_session() as session:
-
         # First read the attribute using `get_attribute`.
         # We can get standard information like name, ID, tags, etc.
         rating_curve_attribute = session.get_attribute(

--- a/src/volue/mesh/tests/test_authentication.py
+++ b/src/volue/mesh/tests/test_authentication.py
@@ -14,7 +14,8 @@ from volue import mesh
 @pytest.fixture
 def auth_metadata_plugin(mesh_test_config):
     """Yields Authentication object. No clean-up is done (it requires Connection object)
-    Note: Depending on the test-case there will be some tokens left (not revoked) in Mesh server."""
+    Note: Depending on the test-case there will be some tokens left (not revoked) in Mesh server.
+    """
     assert mesh_test_config.creds_type == "kerberos"
     credentials = mesh.Credentials(mesh_test_config.tls_root_certs)
     authentication_parameters = mesh.Authentication.Parameters(

--- a/src/volue/mesh/tests/test_performance.py
+++ b/src/volue/mesh/tests/test_performance.py
@@ -70,7 +70,6 @@ def _write_timeseries_points(
 
 
 class PerformanceTestRunner:
-
     # Prefix of new objects created for testing purposes
     NEW_OBJECT_NAME_PREFIX = "TestPowerPlant"
     # Prefix of new objects created for testing purposes
@@ -97,7 +96,6 @@ class PerformanceTestRunner:
         test_case_number_of_points: List[int],
         test_iterations: int,
     ):
-
         self._connection = connection
         self._test_case_number_of_timeseries = test_case_number_of_timeseries
         self._test_case_number_of_points = test_case_number_of_points
@@ -301,7 +299,6 @@ class PerformanceTestRunner:
 
 
 if __name__ == "__main__":
-
     number_of_timeseries = [100, 1000]
     number_of_points = [1, 100, 500, 1000, 10000]
     iterations = 5

--- a/src/volue/mesh/tests/test_rating_curve.py
+++ b/src/volue/mesh/tests/test_rating_curve.py
@@ -136,7 +136,6 @@ def test_get_rating_curve_versions_with_versions_only(session: _base_session.Ses
 
 @pytest.mark.database
 def test_get_rating_curve_versions_invalid_input(session: _base_session.Session):
-
     # [start_time, end_time) must be a valid interval
     with pytest.raises(
         grpc.RpcError, match="UtcInterval .* is invalid, start_time > end_time"
@@ -152,7 +151,6 @@ def test_get_rating_curve_versions_invalid_input(session: _base_session.Session)
 def test_update_rating_curve_versions_remove_one_version(
     session: _base_session.Session,
 ):
-
     # provide all possible attribute target types, like path or ID
     targets = get_targets(session)
 
@@ -178,7 +176,6 @@ def test_update_rating_curve_versions_remove_one_version(
 def test_update_rating_curve_versions_remove_all_versions(
     session: _base_session.Session,
 ):
-
     session.update_rating_curve_versions(
         target=ATTRIBUTE_PATH,
         start_time=datetime.min,

--- a/src/volue/mesh/tests/test_relations.py
+++ b/src/volue/mesh/tests/test_relations.py
@@ -74,7 +74,6 @@ def test_update_one_to_one_link_relation_attribute_with_empty_target_object(sess
 
 @pytest.mark.database
 def test_update_one_to_one_link_relation_attribute_invalid_input(session):
-
     attribute_path = ATTRIBUTE_PATH_PREFIX + ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
 
     # `append` can't be used with one-to-one link relations
@@ -240,7 +239,6 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_one_version(
     targets = get_targets(session, VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME)
 
     for target in targets:
-
         session.update_versioned_link_relation_attribute(
             target=target,
             start_time=datetime(2004, 1, 1),

--- a/src/volue/mesh/tests/test_session.py
+++ b/src/volue/mesh/tests/test_session.py
@@ -35,7 +35,8 @@ def test_can_connect_to_existing_session(connection):
     1. Create a session.
     2. Connect to the session using a new object.
     3. Close using the new session object.
-    4. Try to close the old session object, which should no longer be alive on the server."""
+    4. Try to close the old session object, which should no longer be alive on the server.
+    """
     session = connection.create_session()
     session.open()
     assert session.session_id is not None

--- a/src/volue/mesh/use_cases/use_cases.py
+++ b/src/volue/mesh/use_cases/use_cases.py
@@ -353,7 +353,6 @@ def use_case_3():
 
             timskey_and_pandas_dataframe = []
             for timskey in timskeys:
-
                 # Get information about the time series
                 timeseries_resource = session.get_timeseries_resource_info(
                     timeseries_key=timskey
@@ -409,7 +408,6 @@ def use_case_4():
 
             timskey_and_pandas_dataframe = []
             for guid in guids:
-
                 # Retrieve the time series points in a given interval
                 timeseries = session.read_timeseries_points(
                     target=uuid.UUID(guid), start_time=start, end_time=end
@@ -474,7 +472,6 @@ def use_case_4b():
 
             timskey_and_pandas_dataframe = []
             for path in paths:
-
                 # Retrieve the time series points in a given interval
                 timeseries = session.read_timeseries_points(
                     target=path, start_time=start, end_time=end
@@ -1270,7 +1267,6 @@ def use_case_17():
     connection = Connection(host=HOST, port=PORT)
     with connection.create_session() as session:
         try:
-
             print(f"{use_case_name}:")
             print("--------------------------------------------------------------")
 
@@ -1657,7 +1653,6 @@ def use_case_24():
     connection = Connection(host=HOST, port=PORT)
     with connection.create_session() as session:
         try:
-
             print(f"{use_case_name}:")
             print("--------------------------------------------------------------")
 
@@ -1800,7 +1795,6 @@ def use_case_26():
 
 
 if __name__ == "__main__":
-
     if len(sys.argv) > 1:
         RUN_USE_CASE = sys.argv[1]
 


### PR DESCRIPTION
`lint.yml` github page is using latest black version, meanwhile in `pyproject.toml` in dev section we were limited to version max 22.
Latest `black` version 23 introduces some changes to the style, so 10 files have some minor changes in this PR.