### PR TITLE
Fix `DeprecationWarning: There is no current event loop`

### DIFF
--- a/src/volue/mesh/examples/authorization.py
+++ b/src/volue/mesh/examples/authorization.py
@@ -5,6 +5,31 @@ from volue.mesh import Authentication, Connection
 from volue.mesh.examples import _get_connection_info
 
 
+def sync_auth(address, port, root_pem_certificate, authentication_parameters):
+    print("Synchronous authentication example: ")
+    connection = Connection(
+        address, port, root_pem_certificate, authentication_parameters
+    )
+    user_identity = connection.get_user_identity()
+    print(user_identity)
+
+    # revoke no longer used token
+    connection.revoke_access_token()
+
+
+async def async_auth(address, port, root_pem_certificate, authentication_parameters):
+    print("Asynchronous authentication example:")
+    connection = AsyncConnection(
+        address, port, root_pem_certificate, authentication_parameters
+    )
+
+    user_identity = await connection.get_user_identity()
+    print(user_identity)
+
+    # revoke no longer used token
+    await connection.revoke_access_token()
+
+
 def main(address, port, root_pem_certificate):
     """Showing how to authorize to gRPC Mesh server."""
 
@@ -27,27 +52,10 @@ def main(address, port, root_pem_certificate):
         "HOST/example.companyad.company.com"
     )
 
-    print("Synchronous authentication example: ")
-    connection = Connection(
-        address, port, root_pem_certificate, authentication_parameters
+    sync_auth(address, port, root_pem_certificate, authentication_parameters)
+    asyncio.run(
+        async_auth(address, port, root_pem_certificate, authentication_parameters)
     )
-    user_identity = connection.get_user_identity()
-    print(user_identity)
-
-    # revoke no longer used token
-    connection.revoke_access_token()
-
-    print("Asynchronous authentication example: ")
-    aconnection = AsyncConnection(
-        address, port, root_pem_certificate, authentication_parameters
-    )
-    user_identity = asyncio.get_event_loop().run_until_complete(
-        aconnection.get_user_identity()
-    )
-    print(user_identity)
-
-    # revoke no longer used token
-    asyncio.get_event_loop().run_until_complete(aconnection.revoke_access_token())
 
 
 if __name__ == "__main__":

--- a/src/volue/mesh/examples/get_version.py
+++ b/src/volue/mesh/examples/get_version.py
@@ -1,22 +1,37 @@
-from volue.mesh.aio import Connection as AsyncConnection
+import asyncio
+
 from volue.mesh import Connection
+from volue.mesh.aio import Connection as AsyncConnection
 from volue.mesh.examples import _get_connection_info
 
-import asyncio
+
+def sync_get_version(address, port, root_pem_certificate):
+    print("Synchronous get version:")
+    connection = Connection(address, port, root_pem_certificate)
+    version_info = connection.get_version()
+    print(version_info.version)
+
+
+async def async_get_version(
+    address,
+    port,
+    root_pem_certificate,
+):
+    print("Asynchronous get version:")
+    connection = AsyncConnection(address, port, root_pem_certificate)
+    version_info = await connection.get_version()
+    print(version_info.version)
 
 
 def main(address, port, root_pem_certificate):
     """Showing how to send get the server version both sequentially and concurrently."""
 
-    print("Synchronous get version: ")
-    connection = Connection(address, port, root_pem_certificate)
-    version_info = connection.get_version()
-    print(version_info.version)
-
-    print("Asynchronous get version: ")
-    connection = AsyncConnection(address, port, root_pem_certificate)
-    version_info = asyncio.get_event_loop().run_until_complete(connection.get_version())
-    print(version_info.version)
+    sync_get_version(
+        address,
+        port,
+        root_pem_certificate,
+    )
+    asyncio.run(async_get_version(address, port, root_pem_certificate))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Starting with Python 3.10 a deprecation warning is emitted in 2 examples when using `asyncio.get_event_loop()`.