### PR TITLE
Fix pytest markers

### DIFF
--- a/src/volue/mesh/tests/test_mesh_objects.py
+++ b/src/volue/mesh/tests/test_mesh_objects.py
@@ -276,7 +276,7 @@ def test_object_apis_with_invalid_target(session, invalid_target):
         session.delete_object(invalid_target)
 
 
-@pytest.mark.unittest
+@pytest.mark.server
 def test_object_apis_with_attribute_as_target(session):
     """
     Check that 'get_object', 'search_for_objects', 'update_object' and
@@ -320,7 +320,7 @@ def test_create_and_update_object_with_invalid_target(session, invalid_target):
         session.update_object(OBJECT_PATH, new_owner_attribute=invalid_target)
 
 
-@pytest.mark.unittest
+@pytest.mark.server
 def test_create_and_update_object_with_attribute_as_target(session):
     """
     Check that 'create_object' with object as target and 'update_object' with


### PR DESCRIPTION
Both tests have `session` as input (from test fixture) and it implies we need to be able to make a connection to Mesh server. If there is no Mesh server then gRPC error will be seen before even entering the tests and they will always fail.