### PR TITLE
Revert "Fix usage GitHub action for Python 3.10 on WSL"

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -60,10 +60,6 @@ jobs:
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package
-      #
-      # There is a problem with building the package volue.mesh using latest
-      # pip (i.e. 23) on Python 3.10 on Linux. Downgrade to version 22.3.
-      # As a workaround install either poetry via pip or downgrade to 22.3.
       - name: Install and test Python SDK (Ubuntu 20.04)
         shell: wsl-bash {0}
         run: |
@@ -75,7 +71,6 @@ jobs:
           curl -sS https://bootstrap.pypa.io/get-pip.py | python${{ matrix.python-version }}
           sudo apt-get install --yes libkrb5-dev gcc
           sudo apt-get install --yes python${{ matrix.python-version }}-dev
-          python${{ matrix.python-version }} -m pip install --upgrade pip==22.3
           python${{ matrix.python-version }} -m pip install git+https://github.com/Volue-Public/energy-mesh-python@${{ github.ref }}
           python${{ matrix.python-version }} ./repo/src/volue/mesh/examples/get_version.py
           python${{ matrix.python-version }} -m pip install pytest pytest-asyncio pandas


### PR DESCRIPTION
Reverts Volue-Public/energy-mesh-python#341

Meanwhile pip had an update. I want to check if this is still needed.