### PR TITLE
Automatically extend session lifetime

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/source/mesh_session.rst
+++ b/docs/source/mesh_session.rst
@@ -26,7 +26,7 @@ Currently the session timeout for gRPC sessions is set to 5 minutes.
 The session timeout is counted from the moment where handling of the last
 request made using that session was completed. So, if you are using a session
 for longer period than the session timeout, but you are actively making calls
-to for example read time series points, then the session will not timeout.
+to, for example read time series points, then the session will not timeout.
 
 In cases where a session needs to be preserved, but the inactivity periods are
 longer, then the user needs to make explicit calls using that session.

--- a/docs/source/mesh_session.rst
+++ b/docs/source/mesh_session.rst
@@ -14,3 +14,24 @@ Trying to connect to a session with a session id that is no longer valid will re
 The following example shows some different ways of working with sessions.
 
 .. literalinclude:: /../../src/volue/mesh/examples/working_with_sessions.py
+
+
+Timeout
+~~~~~~~
+
+Each session that has been **inactive** for some period of time will be
+automatically closed on the server side. This period is called session timeout.
+Currently the session timeout for gRPC sessions is set to 5 minutes.
+
+The session timeout is counted from the moment where handling of the last
+request made using that session was completed. So, if you are using a session
+for longer period than the session timeout, but you are actively making calls
+to for example read time series points, then the session will not timeout.
+
+In cases where a session needs to be preserved, but the inactivity periods are
+longer, then the user needs to make explicit calls using that session.
+
+To make working with Mesh via Python SDK more user-friendly the extension of
+session lifetime is handled automatically by the Mesh Python SDK. So as long
+as you have an opened session, the Python SDK will send automatically calls to
+extend the session lifetime in the background.

--- a/docs/source/mesh_session.rst
+++ b/docs/source/mesh_session.rst
@@ -1,5 +1,5 @@
-Session
----------------------------
+Mesh session
+------------
 
 A session can be viewed as temporary workspace where changes will not be affected by, or affect other users, that work with the system until changes are committed and pushed out of the session and into where shared resources are stored.
 
@@ -35,3 +35,10 @@ To make working with Mesh via Python SDK more user-friendly the extension of
 session lifetime is handled automatically by the Mesh Python SDK. So as long
 as you have an opened session, the Python SDK will send automatically calls to
 extend the session lifetime in the background.
+
+In very limited and special use case where you want to connect to already
+existing and opened session via :ref:`api:volue.mesh`.Connection.connect_to_session
+Python SDK will not automatically extend the lifetime of the session. In such
+case the user needs to make explicit calls. This is because tracking of an open
+session that needs automatic lifetime extension is started when it is open via
+Python's :ref:`api:volue.mesh`.Connection.Session object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ markers = [
     "examples: Tests that run the examples.",
     "unittest: Tests that do NOT require a mesh server.",
     "authentication: Tests that require a running mesh server with Kerberos authentication.",
+    "long: Long tests, longer than a minute.",
 ]
 
 [build-system]

--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -62,7 +62,8 @@ class Session(abc.ABC):
             self.event_loop: Optional[asyncio.AbstractEventLoop] = event_loop
 
         def run(self):
-            asyncio.set_event_loop(self.event_loop)
+            if self.event_loop is not None:
+                asyncio.set_event_loop(self.event_loop)
 
             while not self.session.stop_worker_thread.wait(
                 EXTEND_SESSION_LIFETIME_INTERVAL_IN_SECS
@@ -111,12 +112,15 @@ class Session(abc.ABC):
         """
         self.session_id: Optional[uuid.UUID] = session_id
         self.mesh_service: core_pb2_grpc.MeshServiceStub = mesh_service
+
         self.stop_worker_thread: threading.Event = threading.Event()
+        self.worker_thread: Optional[Session.WorkerThread] = None
 
     @abc.abstractmethod
     def open(self) -> None:
         """
         Request to open a session on the Mesh server.
+        An opened session must be closed using the same `Session` object.
 
         Raises:
             grpc.RpcError: Error message raised if the gRPC request could not be completed

--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -1,33 +1,36 @@
+from __future__ import annotations
+
 import abc
-import dateutil
+import asyncio
+import threading
 import typing
-from typing import List, Optional, Tuple, Union
 import uuid
 from datetime import datetime
+from typing import List, Optional, Tuple, Union
 
+import dateutil
 from google import protobuf
 
 from ._attribute import (
+    SIMPLE_TYPE,
+    SIMPLE_TYPE_OR_COLLECTION,
     AttributeBase,
     TimeseriesAttribute,
-    SIMPLE_TYPE_OR_COLLECTION,
-    SIMPLE_TYPE,
 )
 from ._common import (
     AttributesFilter,
     LinkRelationVersion,
-    XyCurve,
-    XySet,
     RatingCurveSegment,
     RatingCurveVersion,
+    XyCurve,
+    XySet,
+    _datetime_to_timestamp_pb2,
     _read_proto_reply,
     _to_proto_attribute_masks,
-    _to_proto_guid,
     _to_proto_curve_type,
-    _datetime_to_timestamp_pb2,
+    _to_proto_guid,
     _to_proto_utcinterval,
 )
-
 from ._mesh_id import (
     _to_proto_attribute_mesh_id,
     _to_proto_object_mesh_id,
@@ -36,17 +39,62 @@ from ._mesh_id import (
 from ._object import Object
 from ._timeseries import Timeseries
 from ._timeseries_resource import TimeseriesResource
-
 from .calc.forecast import ForecastFunctions
 from .calc.history import HistoryFunctions
 from .calc.statistical import StatisticalFunctions
 from .calc.transform import TransformFunctions
-
 from .proto.core.v1alpha import core_pb2, core_pb2_grpc
+
+EXTEND_SESSION_LIFETIME_INTERVAL_IN_SECS = 150
 
 
 class Session(abc.ABC):
+    class WorkerThread(threading.Thread):
+        def __init__(
+            self,
+            session: Session,
+            event_loop: Optional[asyncio.AbstractEventLoop] = None,
+        ):
+            super().__init__()
+            # no resources are acquired, no need to do explicit clean-up
+            self.setDaemon(True)
+            self.session: Session = session
+            self.event_loop: Optional[asyncio.AbstractEventLoop] = event_loop
+
+        def run(self):
+            asyncio.set_event_loop(self.event_loop)
+
+            while not self.session.stop_worker_thread.wait(
+                EXTEND_SESSION_LIFETIME_INTERVAL_IN_SECS
+            ):
+                try:
+                    if self.event_loop is not None:
+                        extend_lifetime_coroutine: typing.Coroutine[
+                            typing.Any, typing.Any, None
+                        ] = self.session._extend_lifetime()
+                        asyncio.run_coroutine_threadsafe(
+                            extend_lifetime_coroutine, self.event_loop
+                        ).result()
+                    else:
+                        self.session._extend_lifetime()
+                except Exception as e:
+                    # In case of an exception just add more descriptive
+                    # message and exit the worker thread.
+                    raise RuntimeError(
+                        f"session {self.session.session_id} worker thread exception"
+                    ) from e
+
     """Represents a session to a Mesh server."""
+
+    def _extend_lifetime(self) -> None:
+        """
+        Request to extend session lifetime on the Mesh server.
+        This is used internally by the Mesh Python SDK and the user does not
+        need to call it explicitly.
+
+        Raises:
+            grpc.RpcError: Error message raised if the gRPC request could not be completed
+        """
 
     def __init__(
         self,
@@ -63,6 +111,7 @@ class Session(abc.ABC):
         """
         self.session_id: Optional[uuid.UUID] = session_id
         self.mesh_service: core_pb2_grpc.MeshServiceStub = mesh_service
+        self.stop_worker_thread: threading.Event = threading.Event()
 
     @abc.abstractmethod
     def open(self) -> None:

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -81,14 +81,13 @@ class Connection(_base_connection.Connection):
             self.session_id = _from_proto_guid(reply)
 
             self.stop_worker_thread.clear()
-            self.worker_thread: _base_session.Session.WorkerThread = (
-                super().WorkerThread(self)
-            )
+            self.worker_thread = super().WorkerThread(self)
             self.worker_thread.start()
 
         def close(self) -> None:
-            self.stop_worker_thread.set()
-            self.worker_thread.join()
+            if self.worker_thread is not None:
+                self.stop_worker_thread.set()
+                self.worker_thread.join()
 
             self.mesh_service.EndSession(_to_proto_guid(self.session_id))
             self.session_id = None

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -83,7 +83,6 @@ class Connection(_base_connection.Connection):
         async def open(self) -> None:
             reply = await self.mesh_service.StartSession(protobuf.empty_pb2.Empty())
             self.session_id = _from_proto_guid(reply)
-            return reply
 
             self.stop_worker_thread.clear()
             self.worker_thread: _base_session.Session.WorkerThread = (

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -85,14 +85,13 @@ class Connection(_base_connection.Connection):
             self.session_id = _from_proto_guid(reply)
 
             self.stop_worker_thread.clear()
-            self.worker_thread: _base_session.Session.WorkerThread = (
-                super().WorkerThread(self, asyncio.get_running_loop())
-            )
+            self.worker_thread = super().WorkerThread(self, asyncio.get_running_loop())
             self.worker_thread.start()
 
         async def close(self) -> None:
-            self.stop_worker_thread.set()
-            self.worker_thread.join()
+            if self.worker_thread is not None:
+                self.stop_worker_thread.set()
+                self.worker_thread.join()
 
             await self.mesh_service.EndSession(_to_proto_guid(self.session_id))
             self.session_id = None

--- a/src/volue/mesh/tests/test_session.py
+++ b/src/volue/mesh/tests/test_session.py
@@ -49,6 +49,9 @@ def test_can_connect_to_existing_session(connection):
     same_session = connection.connect_to_session(session.session_id)
     assert session.session_id == same_session.session_id
     assert session.mesh_service == same_session.mesh_service
+    # This is not how user should work with sessions.
+    # A session opened by one `Session` object MUST be
+    # closed using the same `Session` object.
     same_session.close()
     # Closing a session on the server is not a blocking call,
     # so there is not telling how long closing a session will take.


### PR DESCRIPTION
For each session create a new thread that after 2.5 mins will send `ExtendSession` RPC to Mesh server.
Mark the thread as daemon so it won't block Python's application exit.

The assumption is that the application will have concurrently open rather limited number of sessions, so the overhead of having separate worker thread for each of them will be low.

For async sessions provide the main event loop to the worker thread that will submit `_extend_lifetime` as coroutine and wait until it finishes.

I also added tests that will increase 2-3x times our tests running duration. Most likely I'll deselect them from running per PR in another PR.