### PR TITLE
Add action for long tests

### DIFF
--- a/.github/workflows/install_dev_env/action.yml
+++ b/.github/workflows/install_dev_env/action.yml
@@ -1,0 +1,44 @@
+name: Install development environment
+description: Workflow installs poetry, Mesh Python SDK and Mesh service
+
+inputs:
+  token:
+    required: true
+  python-version:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Installing poetry
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: '1.2.2'
+
+    - name: Poetry install
+      run: poetry install
+      shell: bash
+
+    # Generates the protobuf/gRPC sources and creates the SDK packages
+    - name: Poetry build
+      run: poetry build
+      shell: bash
+
+    - name: Checkout GitHub action
+      uses: actions/checkout@v3
+      with:
+        repository: PowelAS/sme-run-mesh-service
+        ref: master
+        token: ${{ inputs.token }}
+        path: .github/actions
+
+    - name: Install and run Mesh server
+      uses: ./.github/actions/
+      id: download-mesh-server
+      with:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        MESH_SERVICE_TAG: 'v2.10.0.11'

--- a/.github/workflows/long_tests.yml
+++ b/.github/workflows/long_tests.yml
@@ -1,11 +1,8 @@
-name: Development
+name: Long tests
 
 on:
-
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: '0 3 * * *'
 
   workflow_dispatch:
 
@@ -17,18 +14,22 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11]
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+      - name: Check if branch changed
+        run: |
+          echo "NEW_COMMITS=$(git log --since '1 day ago' --oneline | wc -l)" >> "$GITHUB_ENV"
       - name: Install dev environment
+        if: ${{ env.NEW_COMMITS > 0 }}
         uses: ./.github/workflows/install_dev_env
         with:
           python-version: ${{ matrix.python-version }}
           token: ${{ secrets.OAUTH_TOKEN }}
-      - name: Run tests
-        if: ${{ success() }}
+      - name: Run long tests
+        if: ${{ success() && env.NEW_COMMITS > 0 }}
         working-directory: ${{ github.workspace }}
         run: |
-          poetry run pytest -m "not authentication and not long"
+          poetry run pytest -m "long"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Python SDK for Mesh
 
-[![Development](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/development.yml/badge.svg?branch=master)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/development.yml) [![Usage](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/usage.yml/badge.svg?branch=master)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/usage.yml) [![GitHub pages](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/pages.yml/badge.svg)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/pages.yml)  
+[![Long tests](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/long_tests.yml/badge.svg?branch=master)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/long_tests.yml) 
+[![Development](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/development.yml/badge.svg?branch=master)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/development.yml) 
+[![Usage](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/usage.yml/badge.svg?branch=master)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/usage.yml) 
+[![GitHub pages](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/pages.yml/badge.svg)](https://github.com/Volue-Public/energy-mesh-python/actions/workflows/pages.yml)  
 
 
 Mesh Python SDK is a client library used to communicate with Volue Energy's Mesh server. Please refer to:


### PR DESCRIPTION
Extract common part of installing poetry, building Mesh Python SDK and installing Mesh service to `install_dev_env`.
Long tests will be scheduled to run nightly on `master` branch only if there were some changes merged.