### PR TITLE
Constrain Python to ">=3.8, <3.12"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.8, <3.12"
 grpcio = "^1.37.0"
 pyarrow = ">=7.0.0"
 protobuf = ">=3.20.1"


### PR DESCRIPTION
We don't support Python 3.12 at this time. This makes for a much more pleasant error.