### PR TITLE
experimental: add synchronous run_simulation

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -103,3 +103,8 @@ Write time series, asynchronously
 .. literalinclude:: /../../src/volue/mesh/examples/write_timeseries_points_async.py
    :language: python
 
+Run simulations
+***************
+.. literalinclude:: /../../src/volue/mesh/examples/run_simulation.py
+   :language: python
+

--- a/src/volue/mesh/examples/run_simulation.py
+++ b/src/volue/mesh/examples/run_simulation.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from volue import mesh
+from volue.mesh.examples import _get_connection_info
+
+
+def main(address, port, root_pem_certificate):
+    print("connecting...")
+    connection = mesh.Connection(address, port, root_pem_certificate)
+
+    with connection.create_session() as session:
+        start_time = datetime(2023, 11, 1)
+        end_time = datetime(2023, 11, 2)
+
+        print("running simulation...")
+
+        try:
+            for response in session.run_simulation(
+                "Mesh", "Cases", "Demo", start_time, end_time, None, 0, False
+            ):
+                pass
+            print("done")
+        except Exception as e:
+            print(f"failed to run simulation: {e}")
+
+
+if __name__ == "__main__":
+    address, port, root_pem_certificate = _get_connection_info()
+    main(address, port, root_pem_certificate)

--- a/src/volue/mesh/proto/core/v1alpha/core.proto
+++ b/src/volue/mesh/proto/core/v1alpha/core.proto
@@ -245,6 +245,7 @@ service MeshService {
   rpc GetTextResource(GetTextResourceRequest) returns (GetTextResourceResponse) {}
   rpc WriteTextResource(WriteTextResourceRequest) returns (WriteTextResourceResponse) {}
 
+  rpc RunHydroSimulation(SimulationRequest) returns (stream SimulationResponse) {}
 }
 
 message AuthenticateKerberosResponse {
@@ -1255,3 +1256,14 @@ message WriteTextResourceRequest {
 }
 
 message WriteTextResourceResponse {}
+
+message SimulationRequest {
+    volue.mesh.grpc.type.Guid session_id = 1;
+    MeshId simulation = 2;
+    volue.mesh.grpc.type.UtcInterval interval = 3;
+    volue.mesh.grpc.type.Resolution resolution = 4;
+    int32 scenario = 5;
+    bool return_datasets = 6;
+}
+
+message SimulationResponse {}


### PR DESCRIPTION
- No asynchronous implementation as that'll be mildly different.
- No docs.
- One example, no tests. Python unit tests for simulations aren't really feasible as things stand.
- Tested manually using the example.
- No handling of log or dataset returns, the current server doesn't send those.
- No handling of resolution.
- No handling of scenarios, which is currently not supported on the server.
- Interface subject to change.

See https://github.com/Volue/energy-sim/issues/742.