### PR TITLE
experimental: add synchronous run_inflow_calculation

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -108,3 +108,8 @@ Run simulations
 .. literalinclude:: /../../src/volue/mesh/examples/run_simulation.py
    :language: python
 
+Run inflow calculations
+***********************
+.. literalinclude:: /../../src/volue/mesh/examples/run_inflow_calculation.py
+   :language: python
+

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -403,6 +403,36 @@ class Connection(_base_connection.Connection):
             for response in self.mesh_service.RunHydroSimulation(request):
                 yield None
 
+        def run_inflow_calculation(
+            self,
+            model: str,
+            area: str,
+            water_course: str,
+            start_time: datetime,
+            end_time: datetime,
+        ) -> typing.Iterator[None]:
+            if start_time is None or end_time is None:
+                raise TypeError("start_time and end_time must both have a value")
+
+            targets = self.search_for_objects(
+                f"Model/{model}/Mesh.To_Areas/{area}",
+                f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
+            )
+
+            if len(targets) != 1:
+                raise ValueError(f"expected one water course, found {len(targets)}")
+
+            request = core_pb2.SimulationRequest(
+                session_id=_to_proto_guid(self.session_id),
+                simulation=_to_proto_object_mesh_id(targets[0].id),
+                interval=_to_proto_utcinterval(start_time, end_time),
+                scenario=0,
+                return_datasets=False,
+            )
+
+            for response in self.mesh_service.RunInflowCalculation(request):
+                yield None
+
     @staticmethod
     def _secure_grpc_channel(*args, **kwargs):
         return grpc.secure_channel(*args, **kwargs)

--- a/src/volue/mesh/examples/run_inflow_calculation.py
+++ b/src/volue/mesh/examples/run_inflow_calculation.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from volue import mesh
+from volue.mesh.examples import _get_connection_info
+
+
+def main(address, port, root_pem_certificate):
+    print("connecting...")
+    connection = mesh.Connection(address, port, root_pem_certificate)
+
+    with connection.create_session() as session:
+        start_time = datetime(2021, 1, 1)
+        end_time = datetime(2021, 1, 2)
+
+        print("running inflow calculation...")
+
+        try:
+            for response in session.run_inflow_calculation(
+                "Mesh", "Area", "WaterCourse", start_time, end_time
+            ):
+                pass
+            print("done")
+        except Exception as e:
+            print(f"failed to run inflow calculation: {e}")
+
+
+if __name__ == "__main__":
+    address, port, root_pem_certificate = _get_connection_info()
+    main(address, port, root_pem_certificate)

--- a/src/volue/mesh/proto/core/v1alpha/core.proto
+++ b/src/volue/mesh/proto/core/v1alpha/core.proto
@@ -245,7 +245,9 @@ service MeshService {
   rpc GetTextResource(GetTextResourceRequest) returns (GetTextResourceResponse) {}
   rpc WriteTextResource(WriteTextResourceRequest) returns (WriteTextResourceResponse) {}
 
+  // Experimental HydSim API, very unstable.
   rpc RunHydroSimulation(SimulationRequest) returns (stream SimulationResponse) {}
+  rpc RunInflowCalculation(SimulationRequest) returns (stream SimulationResponse) {}
 }
 
 message AuthenticateKerberosResponse {


### PR DESCRIPTION
- No asynchronous implementation as that'll be mildly different.
- No docs.
- Only example, no tests. Python unit tests for inflow calculations aren't really feasible as things stand.
- Tested manually using the example.
- No handling of log or dataset returns, the current server doesn't send those.
- Interface subject to change.

See https://github.com/Volue/energy-sim/issues/742.