### PR TITLE
Use `CaseGroup/CaseName` to refer to hydsim cases

### DIFF
--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -379,7 +379,6 @@ class Connection(_base_connection.Connection):
         def run_simulation(
             self,
             model: str,
-            case_group: str,
             case: str,
             start_time: datetime,
             end_time: datetime,
@@ -390,7 +389,9 @@ class Connection(_base_connection.Connection):
             if start_time is None or end_time is None:
                 raise TypeError("start_time and end_time must both have a value")
 
-            simulation = f"Model/{model}/{case_group}.has_OptimisationCases/{case}.has_OptimisationParameters/Optimal.has_HydroSimulation/HydroSimulation"
+            case_group, case_name = case.split("/", maxsplit=1)
+
+            simulation = f"Model/{model}/{case_group}.has_OptimisationCases/{case_name}.has_OptimisationParameters/Optimal.has_HydroSimulation/HydroSimulation"
 
             request = core_pb2.SimulationRequest(
                 session_id=_to_proto_guid(self.session_id),

--- a/src/volue/mesh/examples/run_simulation.py
+++ b/src/volue/mesh/examples/run_simulation.py
@@ -16,7 +16,7 @@ def main(address, port, root_pem_certificate):
 
         try:
             for response in session.run_simulation(
-                "Mesh", "Cases", "Demo", start_time, end_time, None, 0, False
+                "Mesh", "Cases/Demo", start_time, end_time, None, 0, False
             ):
                 pass
             print("done")


### PR DESCRIPTION
`CaseGroup/CaseName` is established syntax used in various UIs, Optimal Gateway, and Automation Framework. As discussed in https://github.com/Volue/energy-sim/issues/742#issuecomment-1811942095.

There's an argument for more user friendly error handling here, but I think this is API compatible with a future improvement, and I want to get this API break done ASAP. For now you'll get a `ValueError` if the split doesn't split.

Closes https://github.com/Volue-Public/energy-mesh-python/issues/398.