### PR TITLE
experimental: add async HydSim methods

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -108,8 +108,18 @@ Run simulations
 .. literalinclude:: /../../src/volue/mesh/examples/run_simulation.py
    :language: python
 
+Run simulations, asynchronously
+*******************************
+.. literalinclude:: /../../src/volue/mesh/examples/run_simulation_async.py
+   :language: python
+
 Run inflow calculations
 ***********************
 .. literalinclude:: /../../src/volue/mesh/examples/run_inflow_calculation.py
    :language: python
 
+
+Run inflow calculations, asynchronously
+***************************************
+.. literalinclude:: /../../src/volue/mesh/examples/run_inflow_calculation_async.py
+   :language: python

--- a/src/volue/mesh/examples/run_inflow_calculation_async.py
+++ b/src/volue/mesh/examples/run_inflow_calculation_async.py
@@ -1,0 +1,32 @@
+import asyncio
+from datetime import datetime
+
+from volue import mesh
+import volue.mesh.aio
+
+from volue.mesh.examples import _get_connection_info
+
+
+async def main(address, port, root_pem_certificate):
+    print("connecting...")
+    connection = mesh.aio.Connection(address, port, root_pem_certificate)
+
+    async with connection.create_session() as session:
+        start_time = datetime(2021, 1, 1)
+        end_time = datetime(2021, 1, 2)
+
+        print("running inflow calculation...")
+
+        try:
+            async for response in session.run_inflow_calculation(
+                "Mesh", "Area", "WaterCourse", start_time, end_time
+            ):
+                pass
+            print("done")
+        except Exception as e:
+            print(f"failed to run inflow calculation: {e}")
+
+
+if __name__ == "__main__":
+    address, port, root_pem_certificate = _get_connection_info()
+    asyncio.run(main(address, port, root_pem_certificate))

--- a/src/volue/mesh/examples/run_simulation_async.py
+++ b/src/volue/mesh/examples/run_simulation_async.py
@@ -1,0 +1,32 @@
+import asyncio
+from datetime import datetime
+
+from volue import mesh
+import volue.mesh.aio
+
+from volue.mesh.examples import _get_connection_info
+
+
+async def main(address, port, root_pem_certificate):
+    print("connecting...")
+    connection = mesh.aio.Connection(address, port, root_pem_certificate)
+
+    async with connection.create_session() as session:
+        start_time = datetime(2023, 11, 1)
+        end_time = datetime(2023, 11, 2)
+
+        print("running simulation...")
+
+        try:
+            async for response in session.run_simulation(
+                "Mesh", "Cases/Demo", start_time, end_time, None, 0, False
+            ):
+                pass
+            print("done")
+        except Exception as e:
+            print(f"failed to run simulation: {e}")
+
+
+if __name__ == "__main__":
+    address, port, root_pem_certificate = _get_connection_info()
+    asyncio.run(main(address, port, root_pem_certificate))


### PR DESCRIPTION
Includes hydro simulation and inflow calculation. PQ curve generation will be added separately when server support is available. This API is very much subject to change for the near term future.

See https://github.com/Volue/energy-sim/issues/742.

Closes https://github.com/Volue-Public/energy-mesh-python/issues/395.