### PR TITLE
Refactor run_inflow_calculation

### DIFF
--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -400,25 +400,13 @@ class Connection(_base_connection.Connection):
             start_time: datetime,
             end_time: datetime,
         ) -> typing.Iterator[None]:
-            if start_time is None or end_time is None:
-                raise TypeError("start_time and end_time must both have a value")
-
             targets = self.search_for_objects(
                 f"Model/{model}/Mesh.To_Areas/{area}",
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
-
-            if len(targets) != 1:
-                raise ValueError(f"expected one water course, found {len(targets)}")
-
-            request = core_pb2.SimulationRequest(
-                session_id=_to_proto_guid(self.session_id),
-                simulation=_to_proto_object_mesh_id(targets[0].id),
-                interval=_to_proto_utcinterval(start_time, end_time),
-                scenario=0,
-                return_datasets=False,
+            request = self._prepare_run_inflow_calculation_request(
+                targets, start_time, end_time
             )
-
             for response in self.mesh_service.RunInflowCalculation(request):
                 yield None
 

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -405,25 +405,13 @@ class Connection(_base_connection.Connection):
             start_time: datetime,
             end_time: datetime,
         ) -> typing.AsyncIterator[None]:
-            if start_time is None or end_time is None:
-                raise TypeError("start_time and end_time must both have a value")
-
             targets = await self.search_for_objects(
                 f"Model/{model}/Mesh.To_Areas/{area}",
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
-
-            if len(targets) != 1:
-                raise ValueError(f"expected one water course, found {len(targets)}")
-
-            request = core_pb2.SimulationRequest(
-                session_id=_to_proto_guid(self.session_id),
-                simulation=_to_proto_object_mesh_id(targets[0].id),
-                interval=_to_proto_utcinterval(start_time, end_time),
-                scenario=0,
-                return_datasets=False,
+            request = self._prepare_run_inflow_calculation_request(
+                targets, start_time, end_time
             )
-
             async for response in self.mesh_service.RunInflowCalculation(request):
                 yield None
 


### PR DESCRIPTION
- Add abstract method to `_base_session.py`.
- Add barebones docstring. Definintely not final.
- Unify request preparation in `_prepare_run_inflow_calculation_request`.