### PR TITLE
Update run_simulation

### DIFF
--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -5,7 +5,7 @@ import asyncio
 import threading
 import typing
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional, Tuple, Union
 
 import dateutil
@@ -812,11 +812,14 @@ class Session(abc.ABC):
         case: str,
         start_time: datetime,
         end_time: datetime,
-        resolution: Timeseries.Resolution,
-        scenario: int,
-        return_datasets: bool,
+        *,
+        resolution: timedelta = None,
+        scenario: int = None,
+        return_datasets: bool = False,
     ) -> Union[typing.Iterator[None], typing.AsyncIterator[None]]:
         """Run a hydro simulation using HydSim on the Mesh server.
+
+        This function is experimental and subject to larger changes.
 
         Args:
             model: The name of the Mesh model in which the simulation case exists.
@@ -824,10 +827,12 @@ class Session(abc.ABC):
                 'CaseGroup/CaseName'.
             start_time: The (inclusive) start of the simulation interval.
             end_time: The (exclusive) end of the simulation interval.
-            resolution: The resolution of the simulation. Can be left undefined
-                to use the default resolution defined in the simulation case.
-                **Unimplemented.**
-            scenario: The scenario(s) to run. **Unimplemented.**
+            resolution: The resolution of the simulation. The default resolution
+                of the simulation case is used if this is left as `None`.
+                Officially supported resolutions are 5, 10, 15, and 60 minutes,
+                but other resolutions may work. **Unimplemented.**
+            scenario: The scenario(s) to run. All scenarios are run if left as
+                `None`. **Unimplemented.**
             return_datasets: **Unimplemented.**
 
         Returns:

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -2,7 +2,7 @@
 Functionality for synchronously connecting to a Mesh server and working with its sessions.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import typing
 from typing import List, Optional, Union
 import uuid
@@ -382,9 +382,10 @@ class Connection(_base_connection.Connection):
             case: str,
             start_time: datetime,
             end_time: datetime,
-            resolution: Timeseries.Resolution,
-            scenario: int,
-            return_datasets: bool,
+            *,
+            resolution: timedelta = None,
+            scenario: int = None,
+            return_datasets: bool = False,
         ) -> typing.Iterator[None]:
             request = self._prepare_run_simulation_request(
                 model, case, start_time, end_time, resolution, scenario, return_datasets

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -3,7 +3,7 @@ Functionality for asynchronously connecting to a Mesh server and working with it
 """
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 import typing
 from typing import List, Optional, Union
 import uuid
@@ -387,9 +387,10 @@ class Connection(_base_connection.Connection):
             case: str,
             start_time: datetime,
             end_time: datetime,
-            resolution: Timeseries.Resolution,
-            scenario: int,
-            return_datasets: bool,
+            *,
+            resolution: timedelta = None,
+            scenario: int = None,
+            return_datasets: bool = False,
         ) -> typing.AsyncIterator[None]:
             request = self._prepare_run_simulation_request(
                 model, case, start_time, end_time, resolution, scenario, return_datasets

--- a/src/volue/mesh/examples/run_simulation.py
+++ b/src/volue/mesh/examples/run_simulation.py
@@ -19,7 +19,7 @@ def sync_run_simulation(address, port, root_pem_certificate):
 
         try:
             for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time, None, 0, False
+                "Mesh", "Cases/Demo", start_time, end_time
             ):
                 pass
             print("done")
@@ -39,7 +39,7 @@ async def async_run_simulation(address, port, root_pem_certificate):
 
         try:
             async for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time, None, 0, False
+                "Mesh", "Cases/Demo", start_time, end_time
             ):
                 pass
             print("done")


### PR DESCRIPTION
- Make resolution, scenario, and return_datasets optional and keyword only. These arguments have reasonable defaults, and I would like to make them keyword only to provide more oppurtunities for API compatible changes in the future.

- Change the type of resolution to timedelta. This doesn't affect the current version as we don't pass the resolution to the server, but HydSim supports more resolutions than just Mesh time series resolutions, so when we do get there things will make a bit of sense.

@voluetore @tnoczyns-volue this is that last breaking change I'm planning for this release. I'm hoping I can get the final little bit of documentation and a release note up and running today, and then I should be done for the v2.12.0 compatible stuff.