### PR TITLE
Use Mesh 2.12 in GitHub actions

### DIFF
--- a/.github/workflows/install_dev_env/action.yml
+++ b/.github/workflows/install_dev_env/action.yml
@@ -41,4 +41,4 @@ runs:
       id: download-mesh-server
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
-        MESH_SERVICE_TAG: 'v2.11.0.13'
+        MESH_SERVICE_TAG: 'v2.12.0.13'

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -39,7 +39,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.11.0.13'
+          MESH_SERVICE_TAG: 'v2.12.0.13'
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package


### PR DESCRIPTION
Use Mesh 2.12 official build for testing in GitHub actions.