### PR TITLE
Fix GitHub action pages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ six = "^1.16.0"
 
 [tool.poetry.dev-dependencies]
 grpcio-tools = "^1.37.0"
-Sphinx = "^4.0.2"
+Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"
 rtd = "^1.2.3"
 flake8 = "^3.9.2"


### PR DESCRIPTION
When using new poetry on GitHub action Ubuntu runner we're getting:
```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```