### PR TITLE
Changes in handling attribute's owner

### DIFF
--- a/src/volue/mesh/_attribute.py
+++ b/src/volue/mesh/_attribute.py
@@ -136,19 +136,8 @@ class AttributeBase:
         self.id: uuid.UUID = _from_proto_guid(proto_attribute.id)
         self.path: str = proto_attribute.path
         self.name: str = proto_attribute.name
-        # owner_id field is always set starting from Mesh 2.13
-        # TODO: Remove the check if the owner_id field exists when we move to support Mesh >= 2.13
-        # See: https://github.com/Volue/energy-mesh/pull/4755
-        self.owner_id = (
-            _from_proto_guid(proto_attribute.owner_id.id)
-            if proto_attribute.HasField("owner_id")
-            else None
-        )
-        self.owner_path = (
-            proto_attribute.owner_id.path
-            if proto_attribute.HasField("owner_id")
-            else None
-        )
+        self.owner_id: uuid.UUID = _from_proto_guid(proto_attribute.owner_id.id)
+        self.owner_path: str = proto_attribute.owner_id.path
 
         self.definition = None
 


### PR DESCRIPTION
As stated in the removed TODO message:
```
        # owner_id field is always set starting from Mesh 2.13
        # TODO: Remove the check if the owner_id field exists when we move to support Mesh >= 2.13
        # See: https://github.com/Volue/energy-mesh/pull/4755
```