### PR TITLE
hydsim.proto: split requests and responses

### DIFF
--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -1480,36 +1480,33 @@ class Session(abc.ABC):
         resolution: Timeseries.Resolution,
         scenario: int,
         return_datasets: bool,
-    ) -> hydsim_pb2.SimulationRequest:
+    ) -> hydsim_pb2.RunHydroSimulationRequest:
         if start_time is None or end_time is None:
             raise TypeError("start_time and end_time must both have a value")
 
         case_group, case_name = case.split("/", maxsplit=1)
         simulation = f"Model/{model}/{case_group}.has_OptimisationCases/{case_name}.has_OptimisationParameters/Optimal.has_HydroSimulation/HydroSimulation"
 
-        return hydsim_pb2.SimulationRequest(
+        return hydsim_pb2.RunHydroSimulationRequest(
             session_id=_to_proto_guid(self.session_id),
             simulation=_to_proto_object_mesh_id(simulation),
             interval=_to_proto_utcinterval(start_time, end_time),
             scenario=scenario,
-            return_datasets=return_datasets,
         )
 
     def _prepare_run_inflow_calculation_request(
         self, targets: List[Object], start_time: datetime, end_time: datetime
-    ) -> hydsim_pb2.SimulationRequest:
+    ) -> hydsim_pb2.RunInflowCalculationRequest:
         if start_time is None or end_time is None:
             raise TypeError("start_time and end_time must both have a value")
 
         if len(targets) != 1:
             raise ValueError(f"expected one water course, found {len(targets)}")
 
-        return hydsim_pb2.SimulationRequest(
+        return hydsim_pb2.RunInflowCalculationRequest(
             session_id=_to_proto_guid(self.session_id),
-            simulation=_to_proto_object_mesh_id(targets[0].id),
+            watercourse=_to_proto_object_mesh_id(targets[0].id),
             interval=_to_proto_utcinterval(start_time, end_time),
-            scenario=0,
-            return_datasets=False,
         )
 
     def _prepare_get_mc_file_request(
@@ -1527,9 +1524,9 @@ class Session(abc.ABC):
             f"Model/{model}/{case_group}.has_OptimisationCases/{case_name}"
         )
 
-        return hydsim_pb2.SimulationRequest(
+        return hydsim_pb2.GetMcFileRequest(
             session_id=_to_proto_guid(self.session_id),
-            simulation=_to_proto_object_mesh_id(optimisation_case),
+            optimisation_case=_to_proto_object_mesh_id(optimisation_case),
             interval=_to_proto_utcinterval(start_time, end_time),
         )
 

--- a/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
+++ b/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
@@ -6,42 +6,44 @@ import "volue/mesh/proto/type/resources.proto";
 
 // Experimental HydSim API, very unstable.
 service HydsimService {
-  rpc RunHydroSimulation(SimulationRequest) returns (stream SimulationResponse) {}
-  rpc RunInflowCalculation(SimulationRequest) returns (stream SimulationResponse) {}
+  // Run a hydro simulation using HydSim on the Mesh server.
+  rpc RunHydroSimulation(RunHydroSimulationRequest) returns (stream LogOrDataset) {}
+
+  // Run an inflow calculation using HydSim on the Mesh server.
+  rpc RunInflowCalculation(RunInflowCalculationRequest) returns (stream LogOrDataset) {}
 
   // Generate an input file for Marginal Cost from an optimisation case using
   // HydSim.
   //
-  // `session_id` must be set to a valid session, `simulation` must be set to
-  // an optimisation case, and `interval` is the interval to use. The other
-  // arguments are unused.
-  //
   // The return stream will include all the log messages from generating the
   // file, and then end with the JSON contents of the file.
-  rpc GetMcFile(SimulationRequest) returns (stream SimulationResponse) {}
+  rpc GetMcFile(GetMcFileRequest) returns (stream GetMcFileResponse) {}
 }
 
-message SimulationRequest {
+message RunHydroSimulationRequest {
   // The session to use, must be set to the ID of an active session.
   volue.mesh.grpc.type.Guid session_id = 1;
-
-  // The optimisation case to use for `RunHydroSimulation` and `GetMcFile` and
-  // the watercourse to use for `RunInflowCalculation`.
   volue.mesh.grpc.type.MeshId simulation = 2;
-
-  // The interval to use for all HydsimService methods.
   volue.mesh.grpc.type.UtcInterval interval = 3;
-
-  // The resolution to use for `RunHydroSimulation`, not used for
-  // `RunInflowCalculation` or `GetMcFile`.
   volue.mesh.grpc.type.Resolution resolution = 4;
 
-  // The scenario to use for `RunHydroSimulation`, not used for
-  // `RunInflowCalculation` or `GetMcFile`.
+  // The scenario to use. The default of zero runs all scenarios, -1 runs no
+  // scenarios, and a number referring to an existing scenario runs that
+  // scenario.
   int32 scenario = 5;
+}
 
-  // Whether to return datasets, **unimplemented**.
-  bool return_datasets = 6;
+message RunInflowCalculationRequest {
+  volue.mesh.grpc.type.Guid session_id = 1;
+  volue.mesh.grpc.type.MeshId watercourse = 2;
+  volue.mesh.grpc.type.UtcInterval interval = 3;
+  volue.mesh.grpc.type.Resolution resolution = 4;
+}
+
+message GetMcFileRequest {
+  volue.mesh.grpc.type.Guid session_id = 1;
+  volue.mesh.grpc.type.MeshId optimisation_case = 2;
+  volue.mesh.grpc.type.UtcInterval interval = 3;
 }
 
 message SimulationLog {
@@ -49,9 +51,23 @@ message SimulationLog {
   string message = 2;
 }
 
-message SimulationResponse {
+message HydsimDataset {
+  string name = 1;
+  bytes data = 2;
+}
+
+message LogOrDataset {
   oneof response_oneof {
     SimulationLog log_message = 1;
-    string mc_file = 3;
+
+    // Unimplemented.
+    HydsimDataset dataset = 2;
+  }
+}
+
+message GetMcFileResponse {
+  oneof response_oneof {
+    SimulationLog log_message = 1;
+    string mc_file = 2;
   }
 }


### PR DESCRIPTION
gRPC compatibility with Mesh v2.14. Does not affect the Python API.

See https://github.com/Volue/energy-mesh/pull/5179.