### PR TITLE
Add support for getting HydSim datasets

### DIFF
--- a/src/volue/mesh/__init__.py
+++ b/src/volue/mesh/__init__.py
@@ -15,6 +15,7 @@ from ._attribute import (
 from ._object import Object
 from ._common import (
     AttributesFilter,
+    HydSimDataset,
     LinkRelationVersion,
     LogMessage,
     RatingCurveSegment,
@@ -33,6 +34,7 @@ __all__ = [
     "Authentication",
     "Connection",
     "AttributeBase",
+    "HydSimDataset",
     "LinkRelationAttribute",
     "LogMessage",
     "OwnershipRelationAttribute",

--- a/src/volue/mesh/_common.py
+++ b/src/volue/mesh/_common.py
@@ -319,6 +319,23 @@ class LogMessage:
         return cls(level, proto.message)
 
 
+@dataclass
+class HydSimDataset:
+    """A representation of data used in a hydro simulation or inflow calculation.
+
+    The HydSim team may use a dataset to diagnose issues. When Volue requests a
+    dataset we recommend storing datasets with filename `name` and contents
+    from `data` and then sending those files to Volue.
+    """
+
+    name: str
+    data: bytes
+
+    @classmethod
+    def _from_proto(cls, proto):
+        return cls(proto.name, proto.data)
+
+
 def _to_proto_guid(uuid: Optional[uuid.UUID]) -> Optional[type.resources_pb2.Guid]:
     """Converts from Python UUID format to Microsoft's GUID format.
 

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -14,6 +14,7 @@ from volue.mesh import (
     AttributeBase,
     AttributesFilter,
     Authentication,
+    HydSimDataset,
     LogMessage,
     Object,
     Timeseries,
@@ -418,6 +419,8 @@ class Connection(_base_connection.Connection):
             for response in self.hydsim_service.RunHydroSimulation(request):
                 if response.HasField("log_message"):
                     yield LogMessage._from_proto(response.log_message)
+                elif response.HasField("dataset"):
+                    yield HydSimDataset._from_proto(response.dataset)
                 else:
                     yield None
 
@@ -428,17 +431,21 @@ class Connection(_base_connection.Connection):
             water_course: str,
             start_time: datetime,
             end_time: datetime,
+            *,
+            return_datasets: bool = False,
         ) -> typing.Iterator[None]:
             targets = self.search_for_objects(
                 f"Model/{model}/Mesh.To_Areas/{area}",
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
             request = self._prepare_run_inflow_calculation_request(
-                targets, start_time, end_time
+                targets, start_time, end_time, return_datasets
             )
             for response in self.hydsim_service.RunInflowCalculation(request):
                 if response.HasField("log_message"):
                     yield LogMessage._from_proto(response.log_message)
+                elif response.HasField("dataset"):
+                    yield HydSimDataset._from_proto(response.dataset)
                 else:
                     yield None
 

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -15,6 +15,7 @@ from volue.mesh import (
     AttributeBase,
     AttributesFilter,
     Authentication,
+    HydSimDataset,
     LinkRelationVersion,
     LogMessage,
     Object,
@@ -426,6 +427,8 @@ class Connection(_base_connection.Connection):
             async for response in self.hydsim_service.RunHydroSimulation(request):
                 if response.HasField("log_message"):
                     yield LogMessage._from_proto(response.log_message)
+                if response.HasField("dataset"):
+                    yield HydSimDataset._from_proto(response.dataset)
                 else:
                     yield None
 
@@ -436,17 +439,21 @@ class Connection(_base_connection.Connection):
             water_course: str,
             start_time: datetime,
             end_time: datetime,
+            *,
+            return_datasets: bool = False,
         ) -> typing.AsyncIterator[None]:
             targets = await self.search_for_objects(
                 f"Model/{model}/Mesh.To_Areas/{area}",
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
             request = self._prepare_run_inflow_calculation_request(
-                targets, start_time, end_time
+                targets, start_time, end_time, return_datasets
             )
             async for response in self.hydsim_service.RunInflowCalculation(request):
                 if response.HasField("log_message"):
                     yield LogMessage._from_proto(response.log_message)
+                if response.HasField("dataset"):
+                    yield HydSimDataset._from_proto(response.dataset)
                 else:
                     yield None
 

--- a/src/volue/mesh/examples/run_inflow_calculation.py
+++ b/src/volue/mesh/examples/run_inflow_calculation.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime
 
 import helpers
@@ -19,11 +20,20 @@ def sync_run_inflow_calculation(address, port, root_pem_certificate):
 
         try:
             for response in session.run_inflow_calculation(
-                "Mesh", "Area", "WaterCourse", start_time, end_time
+                "Mesh",
+                "Area",
+                "WaterCourse",
+                start_time,
+                end_time,
+                return_datasets=True,
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
                         f"[{logging.getLevelName(response.level)}] {response.message}"
+                    )
+                elif isinstance(response, mesh.HydSimDataset):
+                    print(
+                        f"Received dataset {response.name} with {len(response.data)} bytes"
                     )
             print("done")
         except Exception as e:
@@ -42,11 +52,20 @@ async def async_run_inflow_calculation(address, port, root_pem_certificate):
 
         try:
             async for response in session.run_inflow_calculation(
-                "Mesh", "Area", "WaterCourse", start_time, end_time
+                "Mesh",
+                "Area",
+                "WaterCourse",
+                start_time,
+                end_time,
+                return_datasets=True,
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
                         f"[{logging.getLevelName(response.level)}] {response.message}"
+                    )
+                elif isinstance(response, mesh.HydSimDataset):
+                    print(
+                        f"Received dataset {response.name} with {len(response.data)} bytes"
                     )
             print("done")
         except Exception as e:

--- a/src/volue/mesh/examples/run_simulation.py
+++ b/src/volue/mesh/examples/run_simulation.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime
 
 import helpers
@@ -19,11 +20,15 @@ def sync_run_simulation(address, port, root_pem_certificate):
 
         try:
             for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time
+                "Mesh", "Cases/Demo", start_time, end_time, return_datasets=True
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
                         f"[{logging.getLevelName(response.level)}] {response.message}"
+                    )
+                elif isinstance(response, mesh.HydSimDataset):
+                    print(
+                        f"Received dataset {response.name} with {len(response.data)} bytes"
                     )
             print("done")
         except Exception as e:
@@ -42,11 +47,15 @@ async def async_run_simulation(address, port, root_pem_certificate):
 
         try:
             async for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time
+                "Mesh", "Cases/Demo", start_time, end_time, return_datasets=True
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
                         f"[{logging.getLevelName(response.level)}] {response.message}"
+                    )
+                elif isinstance(response, mesh.HydSimDataset):
+                    print(
+                        f"Received dataset {response.name} with {len(response.data)} bytes"
                     )
             print("done")
         except Exception as e:

--- a/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
+++ b/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
@@ -31,6 +31,13 @@ message RunHydroSimulationRequest {
   // scenarios, and a number referring to an existing scenario runs that
   // scenario.
   int32 scenario = 5;
+
+  // Generate and return HydSim datasets that can be used by Volue to diagnose
+  // issues with hydro simulations. For performance reasons this should be
+  // false when not trying to diagnose an issue.
+  //
+  // See the HydSimDataset message for more information.
+  bool return_datasets = 6;
 }
 
 message RunInflowCalculationRequest {
@@ -38,6 +45,13 @@ message RunInflowCalculationRequest {
   volue.mesh.grpc.type.MeshId watercourse = 2;
   volue.mesh.grpc.type.UtcInterval interval = 3;
   volue.mesh.grpc.type.Resolution resolution = 4;
+
+  // Generate and return HydSim datasets that can be used by Volue to diagnose
+  // issues with inflow calculations. For performance reasons this should be
+  // false when not trying to diagnose an issue.
+  //
+  // See the HydSimDataset message for more information.
+  bool return_datasets = 5;
 }
 
 message GetMcFileRequest {
@@ -51,7 +65,11 @@ message SimulationLog {
   string message = 2;
 }
 
-message HydsimDataset {
+// A HydSim dataset is a representation of data used in a hydro simulation or
+// inflow calculation. The HydSim team may use a dataset to diagnose issues.
+// When Volue requests a dataset we recommend storing datasets with filename
+// `name` and contents from `data` and then sending those files to Volue
+message HydSimDataset {
   string name = 1;
   bytes data = 2;
 }
@@ -59,9 +77,7 @@ message HydsimDataset {
 message LogOrDataset {
   oneof response_oneof {
     SimulationLog log_message = 1;
-
-    // Unimplemented.
-    HydsimDataset dataset = 2;
+    HydSimDataset dataset = 2;
   }
 }
 


### PR DESCRIPTION
A HydSim dataset is a representation of data used in a hydro simulation or inflow calculation. The HydSim team sometimes uses datasets when diagnosing customer issues. Traditionally datasets have been stored on the Mesh server if an attribute with a directory path is non-empty in the Mesh model.

A problem with this setup is that most users shouldn't have access to the Mesh server. When a regular user wants to report a HydSim issue they may need help from a superuser to extract the datasets from the Mesh server. This is not ideal.

Going forward we want Mesh clients that run simulations and inflow calculations to handle datasets on the client side so that it's possible for regular users to access datasets, as well as more convenient for users that might have Mesh access.

This patch adds support for getting HydSim datasets when requesting simulations and inflow calculations using Python. If requested the datasets are streamed to the client together with the log messages we already stream.

See https://github.com/Volue/energy-mesh/pull/5260 (internal) for the server implementation.