### PR TITLE
Fix pandas warning

### DIFF
--- a/src/volue/mesh/tests/test_performance.py
+++ b/src/volue/mesh/tests/test_performance.py
@@ -52,7 +52,7 @@ def _write_timeseries_points(
     number_of_points: int,
 ):
     """Writes random values to specific time series and interval."""
-    timestamps = pd.date_range(start_interval, periods=number_of_points, freq="1H")
+    timestamps = pd.date_range(start_interval, periods=number_of_points, freq="1h")
     flags = [Timeseries.PointFlags.OK.value] * number_of_points
     values = []
     for _ in range(number_of_points):

--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -36,7 +36,7 @@ def get_test_time_series_pyarrow_table(
     # flags - [pa.uint32]
     # value - [pa.float64]
     utc_times = pd.date_range(
-        first_point_timestamp, last_point_timestamp, freq="1H"
+        first_point_timestamp, last_point_timestamp, freq="1h"
     ).tolist()
     flags = [Timeseries.PointFlags.OK.value] * len(utc_times)
     points = list(range(10, 10 + 2 * len(utc_times), 2))


### PR DESCRIPTION
With newer pandas we're getting:
```
FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.
```