### PR TITLE
Fix resolution for simulation and inflow calc

### DIFF
--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -15,7 +15,9 @@ Compatible with
 New features
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- It's now possible to specify the resolution of a hydro simulation or inflow
+  calculation using the optinal `resolution` argument to `run_simulation` and
+  `run_inflow_calculation`. See :doc:`hydsim` for more information.
 
 Changes
 ~~~~~~~~~~~~~~~~~~

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -432,6 +432,7 @@ class Connection(_base_connection.Connection):
             start_time: datetime,
             end_time: datetime,
             *,
+            resolution: timedelta = None,
             return_datasets: bool = False,
         ) -> typing.Iterator[None]:
             targets = self.search_for_objects(
@@ -439,7 +440,7 @@ class Connection(_base_connection.Connection):
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
             request = self._prepare_run_inflow_calculation_request(
-                targets, start_time, end_time, return_datasets
+                targets, start_time, end_time, resolution, return_datasets
             )
             for response in self.hydsim_service.RunInflowCalculation(request):
                 if response.HasField("log_message"):

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -440,6 +440,7 @@ class Connection(_base_connection.Connection):
             start_time: datetime,
             end_time: datetime,
             *,
+            resolution: timedelta = None,
             return_datasets: bool = False,
         ) -> typing.AsyncIterator[None]:
             targets = await self.search_for_objects(
@@ -447,7 +448,7 @@ class Connection(_base_connection.Connection):
                 f"To_HydroProduction/To_WaterCourses/@[.Name={water_course}]",
             )
             request = self._prepare_run_inflow_calculation_request(
-                targets, start_time, end_time, return_datasets
+                targets, start_time, end_time, resolution, return_datasets
             )
             async for response in self.hydsim_service.RunInflowCalculation(request):
                 if response.HasField("log_message"):

--- a/src/volue/mesh/examples/run_inflow_calculation.py
+++ b/src/volue/mesh/examples/run_inflow_calculation.py
@@ -26,6 +26,7 @@ def sync_run_inflow_calculation(address, port, root_pem_certificate):
                 start_time,
                 end_time,
                 return_datasets=True,
+                resolution=timedelta(minutes=5),
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
@@ -58,6 +59,7 @@ async def async_run_inflow_calculation(address, port, root_pem_certificate):
                 start_time,
                 end_time,
                 return_datasets=True,
+                resolution=timedelta(minutes=5),
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(

--- a/src/volue/mesh/examples/run_simulation.py
+++ b/src/volue/mesh/examples/run_simulation.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import helpers
 
@@ -20,7 +20,12 @@ def sync_run_simulation(address, port, root_pem_certificate):
 
         try:
             for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time, return_datasets=True
+                "Mesh",
+                "Cases/Demo",
+                start_time,
+                end_time,
+                return_datasets=True,
+                resolution=timedelta(minutes=5),
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(
@@ -47,7 +52,12 @@ async def async_run_simulation(address, port, root_pem_certificate):
 
         try:
             async for response in session.run_simulation(
-                "Mesh", "Cases/Demo", start_time, end_time, return_datasets=True
+                "Mesh",
+                "Cases/Demo",
+                start_time,
+                end_time,
+                return_datasets=True,
+                resolution=timedelta(minutes=5),
             ):
                 if isinstance(response, mesh.LogMessage):
                     print(

--- a/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
+++ b/src/volue/mesh/proto/hydsim/v1alpha/hydsim.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package volue.mesh.grpc.hydsim.v1alpha;
 
+import "google/protobuf/duration.proto";
+
 import "volue/mesh/proto/type/resources.proto";
 
 // Experimental HydSim API, very unstable.
@@ -25,7 +27,10 @@ message RunHydroSimulationRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
   volue.mesh.grpc.type.MeshId simulation = 2;
   volue.mesh.grpc.type.UtcInterval interval = 3;
-  volue.mesh.grpc.type.Resolution resolution = 4;
+
+  // The resolution to use for the simulation. Must be 5, 10, 15, or 60 minutes.
+  // If left unset the default resolution of the simulation is used.
+  google.protobuf.Duration resolution = 4;
 
   // The scenario to use. The default of zero runs all scenarios, -1 runs no
   // scenarios, and a number referring to an existing scenario runs that
@@ -44,7 +49,10 @@ message RunInflowCalculationRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
   volue.mesh.grpc.type.MeshId watercourse = 2;
   volue.mesh.grpc.type.UtcInterval interval = 3;
-  volue.mesh.grpc.type.Resolution resolution = 4;
+
+  // The resolution to use for the inflow calculation. Must be 5, 10, 15, or 60 minutes.
+  // If left unset the default resolution of the inflow calculation is used.
+  google.protobuf.Duration resolution = 4;
 
   // Generate and return HydSim datasets that can be used by Volue to diagnose
   // issues with inflow calculations. For performance reasons this should be


### PR DESCRIPTION
When implementing run_simulation and run_inflow_calculation I used our predefined protobuf time series resolutions for simulation and inflow calculation resolution. This is not correct and those might run on resolutions we don't allow for time series.

Update proto to use
https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/duration.proto, which is used by the Mesh server starting with v2.14.0.

See https://github.com/Volue/energy-mesh/issues/5305 (internal).
See https://github.com/Volue/energy-mesh/pull/5317 (internal).