### PR TITLE
Add sleep in one auth test

### DIFF
--- a/src/volue/mesh/tests/test_authentication.py
+++ b/src/volue/mesh/tests/test_authentication.py
@@ -3,6 +3,7 @@ Tests for volue.mesh.Authentication
 """
 
 import sys
+import time
 
 import grpc
 import pytest
@@ -86,6 +87,9 @@ def test_auth_metadata_plugin_obtains_correctly_new_token_after_delete(
     assert auth_metadata_plugin.is_token_valid()
     previous_token = auth_metadata_plugin.token
     previous_token_expiration_date = auth_metadata_plugin.token_expiration_date
+
+    # Wait a bit to make sure the new token expiration date is newer than the previous one.
+    time.sleep(0.001)
 
     auth_metadata_plugin.delete_access_token()
     auth_metadata_plugin.get_token()


### PR DESCRIPTION
Occasionally[^1] we are getting new token with the same expiration date as the previous one.

```
test_authentication.py:98: AssertionError

    def test_auth_metadata_plugin_obtains_correctly_new_token_after_delete(
        auth_metadata_plugin,
    ):
        """Check if after deleting access token a new one is correctly obtained."""
        assert auth_metadata_plugin.is_token_valid()
        previous_token = auth_metadata_plugin.token
        previous_token_expiration_date = auth_metadata_plugin.token_expiration_date
        #time.sleep(0.001)
        auth_metadata_plugin.delete_access_token()
        auth_metadata_plugin.get_token()
        new_token = auth_metadata_plugin.token
        new_token_expiration_date = auth_metadata_plugin.token_expiration_date

        assert auth_metadata_plugin.is_token_valid()
        assert new_token is not None
        assert new_token is not previous_token
>       assert previous_token_expiration_date < new_token_expiration_date
E       assert datetime.datetime(2024, 5, 29, 10, 45, 28, 571230, tzinfo=datetime.timezone.utc) < datetime.datetime(2024, 5, 29, 10, 45, 28, 571230, tzinfo=datetime.timezone.utc)

test_authentication.py:99: AssertionError
```

Add 1ms sleep.

[^1]: I've run into this problem 5 out of 15 times.