### PR TITLE
Handle "empty" link relation target objects

### DIFF
--- a/src/volue/mesh/_attribute.py
+++ b/src/volue/mesh/_attribute.py
@@ -433,7 +433,11 @@ class VersionedLinkRelationAttribute(AttributeBase):
             versions: List[LinkRelationVersion] = []
 
             for proto_version in proto_value.versioned_link_relation_value.versions:
-                target_object_id = _from_proto_guid(proto_version.target_object_id)
+                target_object_id = (
+                    _from_proto_guid(proto_version.target_object_id)
+                    if proto_version.HasField("target_object_id")
+                    else None
+                )
                 valid_from_time = proto_version.valid_from_time.ToDatetime(tz.UTC)
                 versions.append(LinkRelationVersion(target_object_id, valid_from_time))
 

--- a/src/volue/mesh/_common.py
+++ b/src/volue/mesh/_common.py
@@ -286,7 +286,7 @@ class LinkRelationVersion:
          :doc:`mesh_relations`
     """
 
-    target_object_id: uuid.UUID
+    target_object_id: Optional[uuid.UUID]
     valid_from_time: datetime.datetime
 
     def __iter__(self):


### PR DESCRIPTION
Partially resolves #470 - specifically the "empty" target objects for versioned link relations, see: https://github.com/Volue/energy-mesh/issues/5425.