### PR TITLE
Adjust to Mesh 2.15

### DIFF
--- a/.github/workflows/install_dev_env/action.yml
+++ b/.github/workflows/install_dev_env/action.yml
@@ -41,4 +41,4 @@ runs:
       id: download-mesh-server
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
-        MESH_SERVICE_TAG: 'v2.14.0.4'
+        MESH_SERVICE_TAG: 'v2.15.0.1960'

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -39,7 +39,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.14.0.4'
+          MESH_SERVICE_TAG: 'v2.15.0.1960'
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -9,7 +9,7 @@ Mesh Python SDK version 1.9.0-dev
 Compatible with
 ~~~~~~~~~~~~~~~~~~
 
-- Mesh server version >= 2.14 **(may change)**
+- Mesh server version >= 2.15 **(may change)**
 - Python [3.9, 3.10, 3.11, 3.12] **(may change)**
 
 New features

--- a/src/volue/mesh/_common.py
+++ b/src/volue/mesh/_common.py
@@ -280,7 +280,8 @@ class LinkRelationVersion:
     """Represents a link relation version.
 
     Contains target object ID and timestamp with the time at which the
-    version becomes active.
+    version becomes active. If target object ID is None, then it means
+    the target object is "empty".
 
     See Also:
          :doc:`mesh_relations`

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -257,15 +257,17 @@ class Connection(_base_connection.Connection):
             )
             self.model_service.UpdateLinkRelationAttribute(request)
 
-        def update_versioned_link_relation_attribute(
+        def update_versioned_one_to_one_link_relation_attribute(
             self,
             target: Union[uuid.UUID, str, AttributeBase],
             start_time: datetime,
             end_time: datetime,
             new_versions: List[LinkRelationVersion],
         ) -> None:
+            # If there are any versions provided then wrap it in additional List to reflect the proto entry.
+            new_versions = [new_versions] if new_versions else new_versions
             request = super()._prepare_versioned_link_relation_attribute_request(
-                target, start_time, end_time, new_versions
+                target, new_versions, start_time, end_time
             )
             self.model_service.UpdateVersionedLinkRelationAttribute(request)
 

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -266,15 +266,17 @@ class Connection(_base_connection.Connection):
             )
             await self.model_service.UpdateLinkRelationAttribute(request)
 
-        async def update_versioned_link_relation_attribute(
+        async def update_versioned_one_to_one_link_relation_attribute(
             self,
             target: Union[uuid.UUID, str, AttributeBase],
             start_time: datetime,
             end_time: datetime,
             new_versions: List[LinkRelationVersion],
         ) -> None:
+            # If there are any versions provided then wrap it in additional List to reflect the proto entry.
+            new_versions = [new_versions] if new_versions else new_versions
             request = super()._prepare_versioned_link_relation_attribute_request(
-                target, start_time, end_time, new_versions
+                target, new_versions, start_time, end_time
             )
             await self.model_service.UpdateVersionedLinkRelationAttribute(request)
 

--- a/src/volue/mesh/examples/working_with_link_relations.py
+++ b/src/volue/mesh/examples/working_with_link_relations.py
@@ -112,7 +112,11 @@ def get_versioned_link_relation_attribute_information(
     for entry_index, entry in enumerate(attribute.entries, 1):
         message += f"Entry {entry_index}\n"
         for version_index, version in enumerate(entry.versions, 1):
-            target_object = session.get_object(version.target_object_id)
+            if version.target_object_id:
+                target_object = session.get_object(version.target_object_id)
+                target_object_name = target_object.name
+            else:
+                target_object_name = "<EMPTY>"
 
             valid_from_time_str = ""
             # If running on Windows and the datetime is before epoch
@@ -131,7 +135,7 @@ def get_versioned_link_relation_attribute_information(
 
             message += (
                 f"\tVersion {version_index}. "
-                f"target object name: {target_object.name}, "
+                f"target object name: {target_object_name}, "
                 f"valid from time: {valid_from_time_str}\n"
             )
 
@@ -149,11 +153,11 @@ def versioned_one_to_one_link_relation_example(session: Connection.Session):
 
     # Remove the first version in entry.
     if len(attribute.entries) > 0 and len(attribute.entries[0].versions) > 0:
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             attribute_path,
             start_time=datetime.min,
             # Replacement interval end time is exclusive,
-            # i.e.: <start_time, end_time).
+            # i.e.: [start_time, end_time).
             # That is why we need to add some small time fraction to make
             # sure the last version's `valid_from_time` is within the
             # replacement interval.
@@ -165,17 +169,24 @@ def versioned_one_to_one_link_relation_example(session: Connection.Session):
     # Add a new version in entry.
     new_target_object_path = OBJECT_PATH + ".PlantToChimneyRef/SomePowerPlantChimney1"
     new_target_object = session.get_object(new_target_object_path)
-    new_link_relation_version = LinkRelationVersion(
+    new_link_relation_version_1 = LinkRelationVersion(
         target_object_id=new_target_object.id,
         # If no time zone is provided then it will be treated as UTC.
         valid_from_time=datetime(2022, 1, 1, tzinfo=LOCAL_TIME_ZONE),
     )
 
-    session.update_versioned_link_relation_attribute(
+    # Add another one, this this with empty target object.
+    new_link_relation_version_2 = LinkRelationVersion(
+        target_object_id=None,
+        # If no time zone is provided then it will be treated as UTC.
+        valid_from_time=datetime(2025, 1, 1, tzinfo=LOCAL_TIME_ZONE),
+    )
+
+    session.update_versioned_one_to_one_link_relation_attribute(
         attribute_path,
-        start_time=new_link_relation_version.valid_from_time,
+        start_time=new_link_relation_version_1.valid_from_time,
         end_time=datetime.max,
-        new_versions=[new_link_relation_version],
+        new_versions=[new_link_relation_version_1, new_link_relation_version_2],
     )
 
     # Read the updated attribute.

--- a/src/volue/mesh/proto/model/v1alpha/model.proto
+++ b/src/volue/mesh/proto/model/v1alpha/model.proto
@@ -399,7 +399,7 @@ message UpdateLinkRelationAttributeRequest {
   //
   // If updating a one-to-many link relation (non-versioned) attribute
   // (`ReferenceCollectionAttribute`) this may contain zero, one or more
-  // `target_object_ids`s. If there is no `target_object_ids` provided and
+  // `target_object_ids`s. If there are no `target_object_ids` provided and
   // `append` is set to false then all currently existing target objects will
   // be removed.
   repeated volue.mesh.grpc.type.Guid target_object_ids = 4;
@@ -408,20 +408,46 @@ message UpdateLinkRelationAttributeRequest {
 message UpdateLinkRelationAttributeResponse {
 }
 
-// Update request message for versioned one-to-one link relation attribute.
+// Update request message for versioned one-to-one link relation and versioned
+// one-to-many link relation attributes.
 message UpdateVersionedLinkRelationAttributeRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
 
-  // All existing versions inside the interval will be deleted.
-  // Passing a `null` interval is an error.
+  // For versioned one-to-one link relation attribute
+  // (`ReferenceSeriesAttribute`) all existing versions with `valid_from_time`
+  // inside the interval will be deleted. Passing a `null` interval is an error.
+  //
+  // Example:
+  //   Existing versions:  |--- ver 1 --->|--- ver 2 --->|--- ver 3 --->
+  //   Request `interval`:           <------------->
+  //   Result:             |---------- ver 1 ----------->|--- ver 3 --->
+  //
+  // For versioned one-to-many link relation attribute
+  // (`ReferenceSeriesCollectionAttribute`) this must set to `null`.
   volue.mesh.grpc.type.UtcInterval interval = 2;
 
   // Versioned one-to-one link relation attribute (`ReferenceSeriesAttribute`)
-  // identifier.
+  // or versioned one-to-many link relation
+  // (`ReferenceSeriesCollectionAttribute`) identifier.
   volue.mesh.grpc.type.MeshId attribute = 3;
 
-  // `valid_from_time` of all `versions` must be inside the interval.
-  repeated LinkRelationVersion versions = 4;
+  // If updating a versioned one-to-one link relation attribute
+  // (`ReferenceSeriesAttribute`):
+  // - Request must contain zero or one `entries`. If there are no `entries`
+  //   provided then currently existing entries will  be removed.
+  // - All `valid_from_time` of all `versions` in the `entries` must be inside
+  //   the interval.
+  // - All `versions` in the `entries` must be sorted in ascending order by
+  //   `valid_from_time`. All `valid_from_time` timestamps must be unique.
+  //
+  // If updating a versioned one-to-many link relation attribute
+  // (`ReferenceSeriesCollectionAttribute`) this may contain zero, one or more
+  // `entries`s. All `versions` in the `entries` must be sorted in ascending
+  // order by `valid_from_time`. All `valid_from_time` timestamps within each
+  // entry must be unique.
+  // If there are no `entries` provided then all currently existing
+  // entries will be removed.
+  repeated VersionedLinkRelationAttributeValue entries = 4;
 }
 
 message UpdateVersionedLinkRelationAttributeResponse {
@@ -458,8 +484,8 @@ message UpdateRatingCurveVersionsRequest {
   volue.mesh.grpc.type.MeshId attribute = 3;
 
   // Update rating curve versions for rating curve attribute. The `from` of all
-  // versions must be inside the interval. All versions must be sorted by
-  // `from`.
+  // versions must be inside the interval. All versions must be sorted in
+  // ascending order by `from`. All `from` timestamps must be unique.
   repeated RatingCurveVersion versions = 4;
 }
 
@@ -505,7 +531,9 @@ message UpdateXySetsRequest {
 
   // If updating a versioned XY set attribute (`XYZSeriesAttribute`) the `XySet`s
   // in `xy_sets` will be inserted in the XY set series. The `valid_from_time` of all
-  // XY sets must be inside the interval.
+  // XY sets must be inside the interval. Provided XY sets do not need to be
+  // sorted by `valid_from_time`. However, all `valid_from_time` timestamps
+  // must be unique.
   //
   // If updating a non-versioned XY set attribute (`XYSetAttribute`) this must contain
   // zero or one `XySet`.

--- a/src/volue/mesh/proto/model/v1alpha/resources.proto
+++ b/src/volue/mesh/proto/model/v1alpha/resources.proto
@@ -113,9 +113,16 @@ message VersionedLinkRelationAttributeValue {
 }
 
 message LinkRelationVersion {
-  volue.mesh.grpc.type.Guid target_object_id = 1;
+  // If `target_object_id` is not set then it will serve as end of activity of
+  // previous target object. E.g.:
+  //   ver1: 01.01.2000 -> object A
+  //   ver2: 02.01.2000 -> _empty_
+  //   ver3: 04.01.2000 -> object B
+  // In the period [02.01.2000, 04.01.2000) no target object was active/linked.
+  optional volue.mesh.grpc.type.Guid target_object_id = 1;
   google.protobuf.Timestamp valid_from_time = 2;
 }
+
 // Defines what attributes need to be returned in response message.
 message AttributesMasks {
   // Attribute name uniquely identifies attribute within given object.

--- a/src/volue/mesh/proto/model_definition/v1alpha/model_definition.proto
+++ b/src/volue/mesh/proto/model_definition/v1alpha/model_definition.proto
@@ -251,7 +251,8 @@ message UpdateObjectDefinitionRequest {
   repeated volue.mesh.grpc.type.Guid new_tag_ids = 6;
 }
 
-message UpdateObjectDefinitionResponse {}
+message UpdateObjectDefinitionResponse {
+}
 
 message DeleteObjectDefinitionRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -260,7 +261,8 @@ message DeleteObjectDefinitionRequest {
   volue.mesh.grpc.type.MeshId object_definition_id = 2;
 }
 
-message DeleteObjectDefinitionResponse {}
+message DeleteObjectDefinitionResponse {
+}
 
 message SearchAttributeDefinitionsRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -534,7 +536,8 @@ message UpdateXySetAttributeTypeRequest {
   repeated volue.mesh.grpc.type.Guid new_tag_ids = 7;
 }
 
-message UpdateAttributeTypeResponse {}
+message UpdateAttributeTypeResponse {
+}
 
 message DeleteAttributeTypeRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -543,7 +546,8 @@ message DeleteAttributeTypeRequest {
   volue.mesh.grpc.type.MeshId attribute_type_id = 2;
 }
 
-message DeleteAttributeTypeResponse {}
+message DeleteAttributeTypeResponse {
+}
 
 message ListModelDefinitionsRequest{
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -768,7 +772,8 @@ message UpdateXySetAttributeDefinitionRequest {
   XySetAxis new_y_axis = 6;
 }
 
-message UpdateAttributeDefinitionResponse {}
+message UpdateAttributeDefinitionResponse {
+}
 
 message DeleteAttributeDefinitionRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -777,7 +782,8 @@ message DeleteAttributeDefinitionRequest {
   volue.mesh.grpc.type.MeshId attribute_definition_id = 2;
 }
 
-message DeleteAttributeDefinitionResponse {}
+message DeleteAttributeDefinitionResponse {
+}
 
 message GetNamespaceRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -825,7 +831,8 @@ message UpdateNamespaceRequest {
   string new_description = 5;
 }
 
-message UpdateNamespaceResponse {}
+message UpdateNamespaceResponse {
+}
 
 message DeleteNamespaceRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -834,7 +841,8 @@ message DeleteNamespaceRequest {
   volue.mesh.grpc.type.MeshId name_space_id = 2;
 }
 
-message DeleteNamespaceResponse {}
+message DeleteNamespaceResponse {
+}
 
 message ListTagsRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -888,7 +896,8 @@ message UpdateTagRequest {
   string new_description = 5;
 }
 
-message UpdateTagResponse {}
+message UpdateTagResponse {
+}
 
 message DeleteTagRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -906,7 +915,8 @@ message DeleteTagRequest {
   bool delete_usages = 3;
 }
 
-message DeleteTagResponse {}
+message DeleteTagResponse {
+}
 
 message ListUnitsOfMeasurementRequest {
   volue.mesh.grpc.type.Guid session_id = 1;
@@ -940,4 +950,5 @@ message SetExtendedMetadataRequest {
   repeated ExtendedMetadata metadata = 3;
 }
 
-message SetExtendedMetadataResponse {}
+message SetExtendedMetadataResponse {
+}

--- a/src/volue/mesh/proto/model_definition/v1alpha/resources.proto
+++ b/src/volue/mesh/proto/model_definition/v1alpha/resources.proto
@@ -151,6 +151,7 @@ message OwnershipRelationAttributeDefinition {
 message LinkRelationAttributeDefinition {
   string target_object_type_name = 1;
   volue.mesh.grpc.type.MeshId target_object_definition_id = 2;
+  bool versioned = 3;
 }
 
 message RatingCurveAttributeDefinition {

--- a/src/volue/mesh/proto/time_series/v1alpha/time_series.proto
+++ b/src/volue/mesh/proto/time_series/v1alpha/time_series.proto
@@ -167,7 +167,8 @@ message Timeseries {
 
   // Data contains an Apache Arrow byte representation of the time series
   // points. Stored in the following columns:
-  // 0: (uint64) utc_time
+  // 0: (timestamp('ms')) utc_time - UTC Unix timestamp expressed in
+  //    milliseconds (internally it is stored as a 64-bit integer)
   // 1: (uint32) flags
   // 2: (double) value
   bytes data = 4;

--- a/src/volue/mesh/tests/test_mesh_objects.py
+++ b/src/volue/mesh/tests/test_mesh_objects.py
@@ -25,7 +25,7 @@ OBJECT_ID = uuid.UUID("0000000A-0001-0000-0000-000000000000")
 
 def verify_object_attributes(object: Object, full_info: bool = False):
     """Verifies all attributes of SomePowerPlant1 object."""
-    assert len(object.attributes) == 31
+    assert len(object.attributes) == 32
 
     for attribute in object.attributes.values():
         assert isinstance(attribute, AttributeBase)

--- a/src/volue/mesh/tests/test_relations.py
+++ b/src/volue/mesh/tests/test_relations.py
@@ -239,7 +239,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_one_version(
     targets = get_targets(session, VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME)
 
     for target in targets:
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             target=target,
             start_time=datetime(2004, 1, 1),
             end_time=datetime(2014, 1, 1),
@@ -270,7 +270,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_all_versions
         ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
     )
 
-    session.update_versioned_link_relation_attribute(
+    session.update_versioned_one_to_one_link_relation_attribute(
         target=attribute_path,
         start_time=datetime.min,
         end_time=datetime.max,
@@ -296,16 +296,24 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_all_versions
 def test_update_versioned_one_to_one_link_relation_attribute_add_new_version(
     session, new_version_valid_from_time: datetime, new_version_index: int
 ):
+    # We have too few chimneys in the existing test model to test various scenarios.
+    # Create new test chimney.
+    new_chimney_owner_attribute_path = ATTRIBUTE_PATH_PREFIX + "PlantToChimneyRef"
+    new_chimney = session.create_object(
+        new_chimney_owner_attribute_path,
+        "SomeNewChimney",
+    )
+
     attribute_path = (
         ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
     )
 
-    new_versions = [LinkRelationVersion(CHIMNEY_1_ID, new_version_valid_from_time)]
+    new_versions = [LinkRelationVersion(new_chimney.id, new_version_valid_from_time)]
 
     # store already existing versions before the update
     old_versions = session.get_attribute(attribute_path).entries[0].versions
 
-    session.update_versioned_link_relation_attribute(
+    session.update_versioned_one_to_one_link_relation_attribute(
         target=attribute_path,
         start_time=new_version_valid_from_time,
         end_time=new_version_valid_from_time + timedelta(microseconds=1),
@@ -319,7 +327,52 @@ def test_update_versioned_one_to_one_link_relation_attribute_add_new_version(
     entry = attribute.entries[0]
     assert len(entry.versions) == 4
 
-    assert entry.versions[new_version_index].target_object_id == CHIMNEY_1_ID
+    assert entry.versions[new_version_index].target_object_id == new_chimney.id
+    # returned timestamps (including `valid_from_time`) are time-zone aware
+    assert entry.versions[
+        new_version_index
+    ].valid_from_time == new_version_valid_from_time.replace(tzinfo=tz.UTC)
+
+    # check that all old versions are still in place
+    assert all(version in entry.versions for version in old_versions)
+
+
+@pytest.mark.database
+@pytest.mark.parametrize(
+    "new_version_valid_from_time, new_version_index",
+    [
+        (datetime(2010, 1, 1), 1),
+        (datetime(2016, 1, 2), 2),
+        (datetime(2022, 1, 1), 3),
+    ],
+)
+def test_update_versioned_one_to_one_link_relation_attribute_add_new_empty_version(
+    session, new_version_valid_from_time: datetime, new_version_index: int
+):
+    attribute_path = (
+        ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
+    )
+
+    new_versions = [LinkRelationVersion(None, new_version_valid_from_time)]
+
+    # store already existing versions before the update
+    old_versions = session.get_attribute(attribute_path).entries[0].versions
+
+    session.update_versioned_one_to_one_link_relation_attribute(
+        target=attribute_path,
+        start_time=new_version_valid_from_time,
+        end_time=new_version_valid_from_time + timedelta(microseconds=1),
+        new_versions=new_versions,
+    )
+
+    attribute = session.get_attribute(attribute_path)
+
+    assert len(attribute.entries) == 1
+
+    entry = attribute.entries[0]
+    assert len(entry.versions) == 4
+
+    assert entry.versions[new_version_index].target_object_id is None
     # returned timestamps (including `valid_from_time`) are time-zone aware
     assert entry.versions[
         new_version_index
@@ -348,13 +401,21 @@ def test_update_versioned_one_to_one_link_relation_attribute_replace_versions(
     new_version_index: int,
     versions_count: int,
 ):
+    # We have too few chimneys in the existing test model to test various scenarios.
+    # Create new test chimney.
+    new_chimney_owner_attribute_path = ATTRIBUTE_PATH_PREFIX + "PlantToChimneyRef"
+    new_chimney = session.create_object(
+        new_chimney_owner_attribute_path,
+        "SomeNewChimney",
+    )
+
     attribute_path = (
         ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
     )
 
-    new_versions = [LinkRelationVersion(CHIMNEY_1_ID, start_time)]
+    new_versions = [LinkRelationVersion(new_chimney.id, start_time)]
 
-    session.update_versioned_link_relation_attribute(
+    session.update_versioned_one_to_one_link_relation_attribute(
         target=attribute_path,
         start_time=start_time,
         end_time=end_time,
@@ -368,7 +429,53 @@ def test_update_versioned_one_to_one_link_relation_attribute_replace_versions(
     entry = attribute.entries[0]
     assert len(entry.versions) == versions_count
 
-    assert entry.versions[new_version_index].target_object_id == CHIMNEY_1_ID
+    assert entry.versions[new_version_index].target_object_id == new_chimney.id
+    # returned timestamps (including `valid_from_time`) are time-zone aware
+    assert entry.versions[new_version_index].valid_from_time == start_time.replace(
+        tzinfo=tz.UTC
+    )
+
+
+@pytest.mark.database
+@pytest.mark.parametrize(
+    "start_time, end_time, new_version_index, versions_count",
+    [
+        (datetime(2005, 1, 1), datetime(2006, 1, 1), 0, 3),
+        (datetime(2005, 1, 1), datetime(2016, 1, 1), 0, 2),
+        (datetime(2005, 1, 1), datetime.max, 0, 1),
+        (datetime(2015, 1, 1), datetime(2020, 1, 1), 1, 2),
+        (datetime(2017, 1, 1), datetime.max, 2, 3),
+        (datetime.min, datetime.max, 0, 1),
+    ],
+)
+def test_update_versioned_one_to_one_link_relation_attribute_replace_versions_with_empty_targets(
+    session,
+    start_time: datetime,
+    end_time: datetime,
+    new_version_index: int,
+    versions_count: int,
+):
+    attribute_path = (
+        ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
+    )
+
+    new_versions = [LinkRelationVersion(None, start_time)]
+
+    session.update_versioned_one_to_one_link_relation_attribute(
+        target=attribute_path,
+        start_time=start_time,
+        end_time=end_time,
+        new_versions=new_versions,
+    )
+
+    attribute = session.get_attribute(attribute_path)
+
+    assert len(attribute.entries) == 1
+
+    entry = attribute.entries[0]
+    assert len(entry.versions) == versions_count
+
+    assert entry.versions[new_version_index].target_object_id is None
     # returned timestamps (including `valid_from_time`) are time-zone aware
     assert entry.versions[new_version_index].valid_from_time == start_time.replace(
         tzinfo=tz.UTC
@@ -387,31 +494,11 @@ def test_update_versioned_one_to_one_link_relation_attribute_with_invalid_interv
         grpc.RpcError,
         match="Interval .* is invalid",
     ):
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             target=attribute_path,
             start_time=datetime(2022, 1, 1),
             end_time=datetime(2021, 1, 1),
             new_versions=[LinkRelationVersion(CHIMNEY_1_ID, datetime(2022, 1, 1))],
-        )
-
-
-@pytest.mark.database
-def test_update_versioned_one_to_one_link_relation_attribute_without_target_object_id(
-    session,
-):
-    attribute_path = (
-        ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
-    )
-
-    with pytest.raises(
-        grpc.RpcError,
-        match="each new link relation version must have a 'target_object_id'",
-    ):
-        session.update_versioned_link_relation_attribute(
-            target=attribute_path,
-            start_time=datetime.min,
-            end_time=datetime.max,
-            new_versions=[LinkRelationVersion(None, datetime(2022, 1, 1))],
         )
 
 
@@ -427,7 +514,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_without_valid_from_
         grpc.RpcError,
         match="each new link relation version must have a 'valid_from_time' timestamp",
     ):
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             target=attribute_path,
             start_time=datetime.min,
             end_time=datetime.max,
@@ -447,7 +534,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_with_valid_from_tim
         grpc.RpcError,
         match="new link relations versions must be within the replacement interval",
     ):
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             target=attribute_path,
             start_time=datetime(2022, 1, 1),
             end_time=datetime.max,
@@ -458,7 +545,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_with_valid_from_tim
         grpc.RpcError,
         match="new link relations versions must be within the replacement interval",
     ):
-        session.update_versioned_link_relation_attribute(
+        session.update_versioned_one_to_one_link_relation_attribute(
             target=attribute_path,
             start_time=datetime.min,
             end_time=datetime(2022, 1, 1),
@@ -493,7 +580,7 @@ async def test_update_versioned_link_relations_async(async_session):
         ATTRIBUTE_PATH_PREFIX + VERSIONED_ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME
     )
 
-    await async_session.update_versioned_link_relation_attribute(
+    await async_session.update_versioned_one_to_one_link_relation_attribute(
         target=attribute_path,
         start_time=datetime.min,
         end_time=datetime.max,


### PR DESCRIPTION
Make current Python SDK compatible with the upcoming Mesh 2.15.
Changes:
* **BREAKING CHANGE**: Rename `update_versioned_link_relation_attribute` to `update_versioned_one_to_one_link_relation_attribute`
* Update proto files.
* Add tests and extend example to show versioned link relations with empty target objects.
