### PR TITLE
Support for updating versioned one-to-many link relations

### DIFF
--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -15,12 +15,17 @@ Compatible with
 New features
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- Support for updating versioned one-to-many link relations. (:pull:`476`)
+
+  See `update_versioned_one_to_many_link_relation_attribute`.
 
 Changes
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- Changes for Mesh server 2.15 gRPC interface compatibility. (:issue:`470`)
+
+  It introduces breaking API change: `update_versioned_link_relation_attribute`
+  is renamed to `update_versioned_one_to_one_link_relation_attribute`.
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,7 +56,7 @@ New features
 Changes
 ~~~~~~~~~~~~~~~~~~
 
-- Changes for Mesh server 2.14 gRPC interface compatibility (:issue:`464`)
+- Changes for Mesh server 2.14 gRPC interface compatibility. (:issue:`464`)
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -86,7 +91,7 @@ Changes
 ~~~~~~~~~~~~~~~~~~
 
 - Handle MIN30 resolution. :pull:`431`
-- Changes for Mesh server 2.13 gRPC interface compatibility (:pull:`427`,
+- Changes for Mesh server 2.13 gRPC interface compatibility. (:pull:`427`,
   :pull:`430`, :pull:`433`, :issue:`384`, :issue:`385`, :issue:`405`, :issue:`423`)
 
 Install instructions

--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -580,6 +580,32 @@ class Session(abc.ABC):
         """
 
     @abc.abstractmethod
+    def update_versioned_one_to_many_link_relation_attribute(
+        self,
+        target: Union[uuid.UUID, str, AttributeBase],
+        new_entries: List[List[LinkRelationVersion]],
+    ) -> None:
+        """
+        Update an existing Mesh versioned one-to-many link relation attribute in
+        the Mesh model.
+
+        Args:
+            target: Mesh one-to-many versioned link relation attribute to be updated.
+                It could be a Universal Unique Identifier or a path in the
+                :ref:`Mesh model <mesh_model>`. See: :ref:`objects and attributes paths
+                <mesh_object_attribute_path>`.
+            new_entries: the list of lists of link relation versions to insert.
+                The first level list represents entries. Each entry can have multiple
+                link relation versions.
+
+        Raises:
+            grpc.RpcError: Error message raised if the gRPC request could not be completed.
+
+        See Also:
+            :doc:`mesh_relations`
+        """
+
+    @abc.abstractmethod
     def get_timeseries_resource_info(self, timeseries_key: int) -> TimeseriesResource:
         """
         Request information (like curve type or resolution) associated with

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -271,6 +271,16 @@ class Connection(_base_connection.Connection):
             )
             self.model_service.UpdateVersionedLinkRelationAttribute(request)
 
+        def update_versioned_one_to_many_link_relation_attribute(
+            self,
+            target: Union[uuid.UUID, str, AttributeBase],
+            new_entries: List[List[LinkRelationVersion]],
+        ) -> None:
+            request = super()._prepare_versioned_link_relation_attribute_request(
+                target, new_entries
+            )
+            self.model_service.UpdateVersionedLinkRelationAttribute(request)
+
         def list_models(
             self,
         ) -> List[Object]:

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -280,6 +280,16 @@ class Connection(_base_connection.Connection):
             )
             await self.model_service.UpdateVersionedLinkRelationAttribute(request)
 
+        async def update_versioned_one_to_many_link_relation_attribute(
+            self,
+            target: Union[uuid.UUID, str, AttributeBase],
+            new_entries: List[List[LinkRelationVersion]],
+        ) -> None:
+            request = super()._prepare_versioned_link_relation_attribute_request(
+                target, new_entries
+            )
+            await self.model_service.UpdateVersionedLinkRelationAttribute(request)
+
         async def list_models(
             self,
         ) -> List[Object]:

--- a/src/volue/mesh/examples/working_with_link_relations.py
+++ b/src/volue/mesh/examples/working_with_link_relations.py
@@ -204,7 +204,48 @@ def versioned_one_to_many_link_relation_example(session: Connection.Session):
     attribute = session.get_attribute(attribute_path)
     print(get_versioned_link_relation_attribute_information(attribute, session))
 
-    print("Update of versioned one-to-many is not supported.")
+    new_target_object_1_path = OBJECT_PATH + ".PlantToChimneyRef/SomePowerPlantChimney1"
+    new_target_object_1 = session.get_object(new_target_object_1_path)
+
+    new_target_object_2_path = OBJECT_PATH + ".PlantToChimneyRef/SomePowerPlantChimney2"
+    new_target_object_2 = session.get_object(new_target_object_2_path)
+
+    entry_1_version_1 = LinkRelationVersion(
+        target_object_id=new_target_object_1.id,
+        # If no time zone is provided then it will be treated as UTC.
+        valid_from_time=datetime(2022, 1, 1, tzinfo=LOCAL_TIME_ZONE),
+    )
+    entry_1_version_2 = LinkRelationVersion(
+        target_object_id=None,
+        # If no time zone is provided then it will be treated as UTC.
+        valid_from_time=datetime(2025, 1, 1, tzinfo=LOCAL_TIME_ZONE),
+    )
+    entry_1_version_3 = LinkRelationVersion(
+        target_object_id=new_target_object_1.id,
+        # If no time zone is provided then it will be treated as UTC.
+        valid_from_time=datetime(2027, 1, 1, tzinfo=LOCAL_TIME_ZONE),
+    )
+    entry1 = [entry_1_version_1, entry_1_version_2, entry_1_version_3]
+
+    entry_2_version_1 = LinkRelationVersion(
+        target_object_id=new_target_object_2.id,
+        valid_from_time=datetime(2000, 1, 1),
+    )
+    entry_2_version_2 = LinkRelationVersion(
+        target_object_id=None,
+        valid_from_time=datetime(2010, 1, 1),
+    )
+    entry2 = [entry_2_version_1, entry_2_version_2]
+
+    new_entries = [entry1, entry2]
+    session.update_versioned_one_to_many_link_relation_attribute(
+        attribute_path, new_entries
+    )
+
+    # Read the updated attribute.
+    attribute = session.get_attribute(attribute_path)
+    print("Updated link relation attribute:")
+    print(get_versioned_link_relation_attribute_information(attribute, session))
 
 
 def main(address, port, tls_root_cert):


### PR DESCRIPTION
* Added new function `update_versioned_one_to_many_link_relation_attribute`
* Added tests
* Extended example
