### PR TITLE
Include connection methods in API documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,13 +6,25 @@ The Mesh Python API contains several packages, namespaces and modules.
 volue.mesh
 ~~~~~~~~~~~~~~~~~~~~
 
+.. We want to include documentation about connection methods, like `with_tls`,
+   defined as class methods on Connection base class.
 .. automodule:: volue.mesh
+    :exclude-members: Connection
+
+    .. autoclass:: Connection
+        :inherited-members:
+        :exclude-members: WorkerThread
 
 
 volue.mesh.aio
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: volue.mesh.aio
+    :exclude-members: Connection
+
+    .. autoclass:: Connection
+        :inherited-members:
+        :exclude-members: WorkerThread
 
 
 volue.mesh.calc


### PR DESCRIPTION
Those are defined as class methods on base class and by default the inherited members are not included in the documentation,
Still we want to add only those specific methods from `Connection` class.
