### PR TITLE
Limit max grpcio and grpcio-tools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.13"
-grpcio = "^1.37.0"
+grpcio = ">=1.37.0, <1.65.0"
 pyarrow = ">=7.0.0"
 protobuf = ">=3.20.1"
 winkerberos = { version = ">=0.9.1", markers = "sys_platform == 'win32'" }
@@ -50,7 +50,7 @@ python-dateutil = "^2.8.2"
 six = "^1.16.0"
 
 [tool.poetry.dev-dependencies]
-grpcio-tools = "^1.37.0"
+grpcio-tools = ">=1.37.0, <1.65.0"
 Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"
 rtd = "^1.2.3"
@@ -75,7 +75,7 @@ markers = [
 [build-system]
 requires = [
     "poetry-core>=1.9.0",
-    "grpcio-tools>=1.60.1"
+    "grpcio-tools>=1.37.0, <1.65.0"
 ]
 build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
Temp WA for extra logs that can mess log parsing systems, it was introduces with grpcio 1.65.0. E.g. when running get_version.py example:
```
Synchronous get version:
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1720778120.895832    6892 config.cc:230] gRPC experiments enabled: call_status_override_on_cancellation, event_engine_client, event_engine_dns, event_engine_listener, http2_stats_fix, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache
99.0.0+0
I0000 00:00:1720778120.904418    6892 work_stealing_thread_pool.cc:269] WorkStealingThreadPoolImpl::Quiesce
Asynchronous get version:
99.0.0+0
I0000 00:00:1720778120.910360    6892 work_stealing_thread_pool.cc:269] WorkStealingThreadPoolImpl::Quiesce
```