### PR TITLE
Fix getting `libkrb5-dev` in GH pages action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,9 @@ jobs:
         path: gh-pages
 
     - name: Install Linux Kerberos dependency
-      run: sudo apt-get install -y libkrb5-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libkrb5-dev
 
     - name: Install poetry
       run: curl -sSL https://install.python-poetry.org | python3 - --version 1.7.1


### PR DESCRIPTION
Example of failing GH action: https://github.com/Volue-Public/energy-mesh-python/actions/runs/10350882693/job/28648213241#step:4:59