### PR TITLE
Lower sleep time in session test

### DIFF
--- a/src/volue/mesh/tests/test_session.py
+++ b/src/volue/mesh/tests/test_session.py
@@ -56,7 +56,7 @@ def test_can_connect_to_existing_session(connection):
     same_session.close()
     # Closing a session on the server is not a blocking call,
     # so there is not telling how long closing a session will take.
-    sleep(61)
+    sleep(1)
     with pytest.raises(grpc.RpcError) as info:
         session.close()
     assert info.type == grpc._channel._InactiveRpcError


### PR DESCRIPTION
It was extended for Mesh 2.11 (in #381 PR). See issue: https://github.com/Volue/energy-mesh/issues/4471.
In Mesh 2.15.3 it was resolved, lower the limit back to 1 second to speed up tests.

**Wait for switching to Mesh 2.15.1 in Mesh Python SDK**