### PR TITLE
Documentation improvements for versions and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ Mesh Python SDK is a client library used to communicate with Volue Energy's Mesh
 
 :blue_book: [Documentation](https://volue-public.github.io/energy-mesh-python/)
 
-Master version of the Mesh Python SDK requires at least 2.13 version of Volue Energy's Mesh server.
+Refer to the [versions page](https://volue-public.github.io/energy-mesh-python/versions.html) to
+check what version of Volue Energy's Mesh server is compatible with the master version of the Mesh
+Python SDK.

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -6,6 +6,8 @@ Depending on the Mesh Server version you intend to communicate with a compatible
 Mesh Python SDK version 1.10.0-dev
 **********************************
 
+This is the current master version.
+
 Compatible with
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Instead of specifying required/compatible Mesh server version in both: versions.rst and README.md, define it only in versions.rst and provide a link in README.md.