### PR TITLE
fix: set upper bound for required poetry-core version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,28 +12,28 @@ packages = [
 ]
 # By default Poetry doesn't package files in .gitignore.
 include = [
-    "src/volue/mesh/proto/auth/v1alpha/auth_pb2.py",
-    "src/volue/mesh/proto/auth/v1alpha/auth_pb2_grpc.py",
-    "src/volue/mesh/proto/calc/v1alpha/calc_pb2.py",
-    "src/volue/mesh/proto/calc/v1alpha/calc_pb2_grpc.py",
-    "src/volue/mesh/proto/config/v1alpha/config_pb2.py",
-    "src/volue/mesh/proto/config/v1alpha/config_pb2_grpc.py",
-    "src/volue/mesh/proto/hydsim/v1alpha/hydsim_pb2.py",
-    "src/volue/mesh/proto/hydsim/v1alpha/hydsim_pb2_grpc.py",
-    "src/volue/mesh/proto/model/v1alpha/model_pb2.py",
-    "src/volue/mesh/proto/model/v1alpha/model_pb2_grpc.py",
-    "src/volue/mesh/proto/model/v1alpha/resources_pb2.py",
-    "src/volue/mesh/proto/model/v1alpha/resources_pb2_grpc.py",
-    "src/volue/mesh/proto/model_definition/v1alpha/model_definition_pb2.py",
-    "src/volue/mesh/proto/model_definition/v1alpha/model_definition_pb2_grpc.py",
-    "src/volue/mesh/proto/model_definition/v1alpha/resources_pb2.py",
-    "src/volue/mesh/proto/model_definition/v1alpha/resources_pb2_grpc.py",
-    "src/volue/mesh/proto/session/v1alpha/session_pb2.py",
-    "src/volue/mesh/proto/session/v1alpha/session_pb2_grpc.py",
-    "src/volue/mesh/proto/time_series/v1alpha/time_series_pb2.py",
-    "src/volue/mesh/proto/time_series/v1alpha/time_series_pb2_grpc.py",
-    "src/volue/mesh/proto/type/resources_pb2.py",
-    "src/volue/mesh/proto/type/resources_pb2_grpc.py"
+    { path = "src/volue/mesh/proto/auth/v1alpha/auth_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/auth/v1alpha/auth_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/calc/v1alpha/calc_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/calc/v1alpha/calc_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/config/v1alpha/config_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/config/v1alpha/config_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/hydsim/v1alpha/hydsim_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/hydsim/v1alpha/hydsim_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model/v1alpha/model_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model/v1alpha/model_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model/v1alpha/resources_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model/v1alpha/resources_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model_definition/v1alpha/model_definition_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model_definition/v1alpha/model_definition_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model_definition/v1alpha/resources_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/model_definition/v1alpha/resources_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/session/v1alpha/session_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/session/v1alpha/session_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/time_series/v1alpha/time_series_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/time_series/v1alpha/time_series_pb2_grpc.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/type/resources_pb2.py", format = ["sdist", "wheel"] },
+    { path = "src/volue/mesh/proto/type/resources_pb2_grpc.py", format = ["sdist", "wheel"] }
 ]
 
 [tool.poetry.dependencies]
@@ -75,7 +75,7 @@ markers = [
 
 [build-system]
 requires = [
-    "poetry-core>=1.9.0",
+    "poetry-core>=1.8.5, <2.0.0",
     "grpcio-tools>=1.37.0, <=1.66.1"
 ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
One of the steps to address #526 

With poetry-core 2.0.0 there was a breaking change introduced:
https://python-poetry.org/blog/announcing-poetry-2.0.0#consistent-include-behavior

This affected the way we included generated python proto stubs. Namely by default if a VCS is used by default ignored files will be excluded. To avoid this we need to explicitly set needed files in `include` section. Include has higher priority than exclude rules.
For more info see: https://python-poetry.org/docs/pyproject#exclude-and-include

However, until now we didn't use `format` option. With poetry-core 2.0.0 if format is not specified the file is only included in sdist, previously it was sdist and wheel.

This PR makes the include section poetry-core 2.0.0 compatible, but also limits the max poetry-core version (< 2.0.0) to avoid similar compatibility surprises in the future.

Additionally, I set the minimum poetry-core version to 1.8.5 as 1.9.x are not included in pipx.