### PR TITLE
fix: env for python 3.12 tests

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -67,11 +67,16 @@ jobs:
           sudo apt-get install --yes software-properties-common
           sudo add-apt-repository --yes ppa:deadsnakes/ppa
           sudo apt-get install --yes python${{ matrix.python-version }}
-          sudo apt-get install --yes python${{ matrix.python-version }}-distutils
+
+          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
+            sudo apt-get install --yes python${{ matrix.python-version }}-distutils
+          else
+            :  # not needed for newer Python versions
+          fi
+
           curl -sS https://bootstrap.pypa.io/get-pip.py | python${{ matrix.python-version }}
           sudo apt-get install --yes libkrb5-dev gcc
           sudo apt-get install --yes python${{ matrix.python-version }}-dev
-          python${{ matrix.python-version }} -m pip install --upgrade setuptools
           python${{ matrix.python-version }} -m pip install git+https://github.com/Volue-Public/energy-mesh-python@${{ github.ref }}
           python${{ matrix.python-version }} ./repo/src/volue/mesh/examples/get_version.py
           python${{ matrix.python-version }} -m pip install pytest pytest-asyncio==0.21.2 pandas


### PR DESCRIPTION
For Python 3.12 we recently started getting:
```
E: Unable to locate package python3.12-distutils
E: Couldn't find any package by glob 'python3.12-distutils'
E: Couldn't find any package by regex 'python3.12-distutils'
```

Install `distutils` only for Python 3.9. For newer versions we can live without this.