### PR TITLE
chore: do not include tests and examples in the package

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -49,7 +49,7 @@ jobs:
           python ./repo/src/volue/mesh/examples/get_version.py
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           python -m pip install pytest pytest-asyncio==0.21.2 pandas
-          python -m pytest --pyargs volue.mesh.tests -m "not authentication and not long"
+          python -m pytest ./repo/src/volue/mesh/tests -m "not authentication and not long"
 
       - name: Install Ubuntu 22.04 (wsl1)
         uses: Vampire/setup-wsl@v1
@@ -75,4 +75,4 @@ jobs:
           python${{ matrix.python-version }} -m pip install git+https://github.com/Volue-Public/energy-mesh-python@${{ github.ref }}
           python${{ matrix.python-version }} ./repo/src/volue/mesh/examples/get_version.py
           python${{ matrix.python-version }} -m pip install pytest pytest-asyncio==0.21.2 pandas
-          python${{ matrix.python-version }} -m pytest --pyargs volue.mesh.tests -m "not authentication and not long"
+          python${{ matrix.python-version }} -m pytest ./repo/src/volue/mesh/tests -m "not authentication and not long"

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -22,7 +22,7 @@ New features
 Changes
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- Do not include tests and examples in the `volue.mesh` package. :pull:`529`
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ include = [
     { path = "src/volue/mesh/proto/type/resources_pb2.py", format = ["sdist", "wheel"] },
     { path = "src/volue/mesh/proto/type/resources_pb2_grpc.py", format = ["sdist", "wheel"] }
 ]
+exclude = [
+    "src/volue/mesh/examples/**",
+    "src/volue/mesh/tests/**",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.13"
@@ -50,7 +54,7 @@ python-dateutil = "^2.8.2"
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1857492
 six = "^1.16.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 grpcio-tools = ">=1.37.0, <=1.66.1"
 Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"

--- a/src/volue/mesh/tests/test_attributes.py
+++ b/src/volue/mesh/tests/test_attributes.py
@@ -12,7 +12,8 @@ import pytest
 from dateutil import tz
 
 from volue.mesh import AttributeBase, Timeseries, TimeseriesAttribute
-from volue.mesh.tests.test_utilities.utilities import CHIMNEY_1_ID, CHIMNEY_2_ID
+
+from .test_utilities.utilities import CHIMNEY_1_ID, CHIMNEY_2_ID
 
 ATTRIBUTE_PATH_PREFIX = "Model/SimpleThermalTestModel/ThermalComponent.ThermalPowerToPlantRef/SomePowerPlant1."
 

--- a/src/volue/mesh/tests/test_mesh_id.py
+++ b/src/volue/mesh/tests/test_mesh_id.py
@@ -8,10 +8,8 @@ import uuid
 import pytest
 
 from volue.mesh import Timeseries, _common, _mesh_id
-from volue.mesh.tests.test_utilities.utilities import (
-    AttributeForTesting,
-    ObjectForTesting,
-)
+
+from .test_utilities.utilities import AttributeForTesting, ObjectForTesting
 
 
 @pytest.mark.unittest

--- a/src/volue/mesh/tests/test_mesh_objects.py
+++ b/src/volue/mesh/tests/test_mesh_objects.py
@@ -14,10 +14,8 @@ from volue.mesh import (
     Object,
     OwnershipRelationAttribute,
 )
-from volue.mesh.tests.test_utilities.utilities import (
-    AttributeForTesting,
-    ObjectForTesting,
-)
+
+from .test_utilities.utilities import AttributeForTesting, ObjectForTesting
 
 OBJECT_PATH = "Model/SimpleThermalTestModel/ThermalComponent.ThermalPowerToPlantRef/SomePowerPlant1"
 OBJECT_ID = uuid.UUID("0000000A-0001-0000-0000-000000000000")

--- a/src/volue/mesh/tests/test_relations.py
+++ b/src/volue/mesh/tests/test_relations.py
@@ -10,7 +10,8 @@ import pytest
 from dateutil import tz
 
 from volue.mesh import LinkRelationVersion
-from volue.mesh.tests.test_utilities.utilities import CHIMNEY_1_ID, CHIMNEY_2_ID
+
+from .test_utilities.utilities import CHIMNEY_1_ID, CHIMNEY_2_ID
 
 ONE_TO_ONE_LINK_RELATION_ATTRIBUTE_NAME = "SimpleReference"
 ONE_TO_MANY_LINK_RELATION_ATTRIBUTE_NAME = "PlantToChimneyRefCollection"


### PR DESCRIPTION
* Exclude tests and examples from the package
* Use `poetry.group.dev.dependencies`[^1]. `poetry.dev-dependencies` is deprecated in Poetry 2.0. 

[^1]: This is the proper way of defining dev deps since Poetry 1.2.0. See: See: https://python-poetry.org/docs/1.8/managing-dependencies/