### PR TITLE
Support for new way of sending empty time series

### DIFF
--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -22,6 +22,18 @@ New features
 Changes
 ~~~~~~~~~~~~~~~~~~
 
+- Support for new way of sending empty time series. :pull:`538`
+
+  **This introduces breaking change for use cases with reading time series with
+  no points.**
+
+  Starting from Mesh 2.17 when an empty time series is read (e.g.: break point
+  time series with no values), instead of raising an `ValueError` with message
+  `No data in time series reply for the given interval`, we will now return 
+  `volue.mesh.Timeseries` instance with an empty Arrow table and start/end
+  timestamps set to `None`. Other time series metadata like resolution will be
+  set as usual.
+
 - Support for *undefined* time series resolution. :pull:`535`
 - Do not include tests and examples in the `volue.mesh` package. :pull:`529`
 

--- a/src/volue/mesh/_connection.py
+++ b/src/volue/mesh/_connection.py
@@ -33,7 +33,6 @@ from volue.mesh._common import (
     _to_proto_curve_type,
     _to_proto_guid,
     _to_proto_resolution,
-    _to_proto_timeseries,
 )
 from volue.mesh.calc.forecast import ForecastFunctions
 from volue.mesh.calc.history import HistoryFunctions
@@ -147,12 +146,8 @@ class Connection(_base_connection.Connection):
             return gen.send(self.time_series_service.ReadTimeseries(request))
 
         def write_timeseries_points(self, timeseries: Timeseries) -> None:
-            self.time_series_service.WriteTimeseries(
-                time_series_pb2.WriteTimeseriesRequest(
-                    session_id=_to_proto_guid(self.session_id),
-                    timeseries=_to_proto_timeseries(timeseries),
-                )
-            )
+            request = super()._prepare_write_timeseries_points_request(timeseries)
+            self.time_series_service.WriteTimeseries(request)
 
         def get_timeseries_resource_info(
             self, timeseries_key: int

--- a/src/volue/mesh/_timeseries.py
+++ b/src/volue/mesh/_timeseries.py
@@ -156,6 +156,9 @@ class Timeseries:
         if start_time is None:
             if self.arrow_table and self.arrow_table.num_rows > 0:
                 self.start_time = self.arrow_table["utc_time"][0].as_py()
+            else:
+                # Means we have an empty time series
+                self.start_time = None
         else:
             self.start_time = start_time
 
@@ -165,6 +168,9 @@ class Timeseries:
                 self.end_time = self.arrow_table["utc_time"][-1].as_py() + timedelta(
                     seconds=1
                 )
+            else:
+                # Means we have an empty time series
+                self.end_time = None
         else:
             self.end_time = end_time
 

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -37,7 +37,6 @@ from volue.mesh._common import (
     _to_proto_curve_type,
     _to_proto_guid,
     _to_proto_resolution,
-    _to_proto_timeseries,
 )
 from volue.mesh.calc.forecast import ForecastFunctionsAsync
 from volue.mesh.calc.history import HistoryFunctionsAsync
@@ -152,12 +151,8 @@ class Connection(_base_connection.Connection):
             return gen.send(await self.time_series_service.ReadTimeseries(request))
 
         async def write_timeseries_points(self, timeseries: Timeseries) -> None:
-            await self.time_series_service.WriteTimeseries(
-                time_series_pb2.WriteTimeseriesRequest(
-                    session_id=_to_proto_guid(self.session_id),
-                    timeseries=_to_proto_timeseries(timeseries),
-                )
-            )
+            request = super()._prepare_write_timeseries_points_request(timeseries)
+            await self.time_series_service.WriteTimeseries(request)
 
         async def get_timeseries_resource_info(
             self, timeseries_key: int

--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -491,8 +491,7 @@ def test_remove_timeseries_points_without_providing_write_interval(session):
     attribute_path = TIME_SERIES_ATTRIBUTE_WITH_PHYSICAL_TIME_SERIES_PATH
 
     with pytest.raises(
-        AttributeError,
-        match="'Timeseries' object has no attribute 'start_time'",
+        TypeError, match="time series start_time and end_time must both have a value"
     ):
         session.write_timeseries_points(
             Timeseries(
@@ -503,8 +502,7 @@ def test_remove_timeseries_points_without_providing_write_interval(session):
         )
 
     with pytest.raises(
-        AttributeError,
-        match="'Timeseries' object has no attribute 'start_time'",
+        TypeError, match="time series start_time and end_time must both have a value"
     ):
         session.write_timeseries_points(
             Timeseries(
@@ -514,8 +512,7 @@ def test_remove_timeseries_points_without_providing_write_interval(session):
         )
 
     with pytest.raises(
-        AttributeError,
-        match="'Timeseries' object has no attribute 'end_time'",
+        TypeError, match="time series start_time and end_time must both have a value"
     ):
         session.write_timeseries_points(
             Timeseries(

--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -644,6 +644,30 @@ def test_write_unsorted_timeseries_points(session):
         session.write_timeseries_points(timeseries)
 
 
+@pytest.mark.database
+def test_read_empty_timeseries(session):
+    """
+    Check that reading empty time series (without any points) is correctly handled.
+    """
+    empty_time_series_key = 9
+    start_time = datetime(2016, 1, 1)
+    end_time = datetime(2025, 1, 1)
+
+    reply_timeseries = session.read_timeseries_points(
+        empty_time_series_key, start_time, end_time
+    )
+
+    assert reply_timeseries.arrow_table is not None
+    assert reply_timeseries.arrow_table.num_rows == 0
+    # This check is redundant, but it is good to have it.
+    assert reply_timeseries.number_of_points == 0
+
+    assert reply_timeseries.start_time is None
+    assert reply_timeseries.end_time is None
+    assert reply_timeseries.resolution == Timeseries.Resolution.BREAKPOINT
+    assert reply_timeseries.timskey == empty_time_series_key
+
+
 @pytest.mark.asyncio
 @pytest.mark.database
 async def test_timeseries_async(async_session):


### PR DESCRIPTION
Starting from Mesh 2.17 when an empty time series is read (e.g.: break point time series with no values), instead of raising an `ValueError` with message `No data in time series reply for the given interval`, we will now return `volue.mesh.Timeseries` instance with an empty Arrow table and start/end timestamps set to `None`. Other time series metadata like resolution will be set as usual.

This PR needs new Mesh server release to pass the new test.