### PR TITLE
chore: switch to current Mesh 2.17 master build

### DIFF
--- a/.github/workflows/install_dev_env/action.yml
+++ b/.github/workflows/install_dev_env/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Installing poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:
-        poetry-version: '1.7.1'
+        poetry-version: "1.7.1"
 
     - name: Poetry install
       run: poetry install
@@ -41,4 +41,4 @@ runs:
       id: download-mesh-server
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
-        MESH_SERVICE_TAG: 'v2.15.0.5'
+        MESH_SERVICE_TAG: "v2.17.0.2283"

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -2,9 +2,9 @@ name: Usage
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   workflow_dispatch:
 
@@ -39,7 +39,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: 'v2.15.0.5'
+          MESH_SERVICE_TAG: "v2.17.0.2283"
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package
@@ -55,8 +55,8 @@ jobs:
         uses: Vampire/setup-wsl@v1
         with:
           distribution: Ubuntu-22.04
-          set-as-default: 'true'
-          update: 'false'
+          set-as-default: "true"
+          update: "false"
 
       # run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package

--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -50,7 +50,6 @@ def verify_physical_timeseries(reply_timeseries: Timeseries):
     Verify if all time series properties and data have expected values.
     "Model/SimpleThermalTestModel/ThermalComponent/SomePowerPlant1/SomePowerPlantChimney2.TsRawAtt"
     """
-    assert reply_timeseries.timskey == 3
     assert reply_timeseries.resolution == Timeseries.Resolution.HOUR
 
     assert type(reply_timeseries) is Timeseries
@@ -310,6 +309,13 @@ def test_read_physical_timeseries_points(session):
         )
         verify_physical_timeseries(reply_timeseries)
 
+        # If we are reading physical time series by time series attribute
+        # (path, ID or object) then no time series key is returned (meaning 0).
+        # If we are reading physical time series directly via time series key,
+        # then the key should be returned.
+        expected_timeseries_key = target if isinstance(target, int) else 0
+        assert reply_timeseries.timskey == expected_timeseries_key
+
 
 @pytest.mark.database
 def test_read_calculation_timeseries_points(session):
@@ -368,6 +374,7 @@ def test_read_timeseries_points_with_different_datetime_timezones(
         TIME_SERIES_ATTRIBUTE_WITH_PHYSICAL_TIME_SERIES_PATH, start_time, end_time
     )
     verify_physical_timeseries(reply_timeseries)
+    assert reply_timeseries.timskey == 0
 
 
 @pytest.mark.database


### PR DESCRIPTION
* Switch to current Mesh 2.17 master build
* Adjust tests to changes with requested time series ID. If requesting points for a time series attribute we no longer return ID (and time series key) of connected physical time series (if any). Instead we return the same ID as in the request.

See example:
* Time series attribute `TsAtt` is connected to physical time series with time series key equal 100
* Client requests time series points for `TsAtt` providing e.g. time series path like: "Model/MyModel/MyObject.TsAtt"
* For Mesh server versions <= 2.16 we returned time series points with ID, path and time series key of to the physical time series.
  * _ID_OF_PHYSICAL_TIME_SERIES_
  * Path = "Resource/MyResourceCatalog/MyPhysicalTimeseries"
  * Key = 100
* Starting with Mesh 2.17 we return time series points with ID and path (no time series key for time series attribute!) of the time series attribute.
  * _ID_OF_TIME_SERIES_ATTRIBUTE_
  * Path = "Model/MyModel/MyObject.TsAtt"
  * time series attributes are not identified by time series keys
