### PR TITLE
temporary fix for relation tests

### DIFF
--- a/src/volue/mesh/_mesh_id.py
+++ b/src/volue/mesh/_mesh_id.py
@@ -11,7 +11,7 @@ from volue.mesh.proto import type
 
 
 def _to_proto_attribute_mesh_id(
-    target: Union[uuid.UUID, str, AttributeBase]
+    target: Union[uuid.UUID, str, AttributeBase],
 ) -> type.resources_pb2.MeshId:
     """
     Accepts attribute identifiers (path and ID) and attribute instance as
@@ -26,7 +26,7 @@ def _to_proto_attribute_mesh_id(
 
 
 def _to_proto_object_mesh_id(
-    target: Union[uuid.UUID, str, Object]
+    target: Union[uuid.UUID, str, Object],
 ) -> type.resources_pb2.MeshId:
     """
     Accepts object identifiers (path and ID) and object instance as input.
@@ -40,7 +40,7 @@ def _to_proto_object_mesh_id(
 
 
 def _to_proto_read_timeseries_mesh_id(
-    target: Union[uuid.UUID, str, int, AttributeBase]
+    target: Union[uuid.UUID, str, int, AttributeBase],
 ) -> type.resources_pb2.MeshId:
     """
     Accepts identifiers for reading time series:
@@ -55,7 +55,7 @@ def _to_proto_read_timeseries_mesh_id(
 
 
 def _to_proto_calculation_target_mesh_id(
-    target: Union[uuid.UUID, str, int, AttributeBase, Object]
+    target: Union[uuid.UUID, str, int, AttributeBase, Object],
 ) -> type.resources_pb2.MeshId:
     """
     Accepts identifiers for calculation target (`relative_to` in gRPC):
@@ -70,7 +70,7 @@ def _to_proto_calculation_target_mesh_id(
 
 
 def _to_proto_mesh_id(
-    target: Union[uuid.UUID, str, int, AttributeBase, Object]
+    target: Union[uuid.UUID, str, int, AttributeBase, Object],
 ) -> type.resources_pb2.MeshId:
     """Accepts path, ID and time series key as input."""
     proto_mesh_id = type.resources_pb2.MeshId()

--- a/src/volue/mesh/tests/test_relations.py
+++ b/src/volue/mesh/tests/test_relations.py
@@ -280,8 +280,10 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_all_versions
 
     attribute = session.get_attribute(attribute_path)
 
-    assert len(attribute.entries) == 1
-    assert len(attribute.entries[0].versions) == 0
+    # TODO: change to after Mesh 2.18 RC
+    assert len(attribute.entries) in {0, 1}
+    if len(attribute.entries) == 1:
+        assert len(attribute.entries[0].versions) == 0
 
 
 @pytest.mark.database
@@ -660,8 +662,10 @@ async def test_update_versioned_one_to_one_link_relations_async(async_session):
 
     attribute = await async_session.get_attribute(attribute_path)
 
-    assert len(attribute.entries) == 1
-    assert len(attribute.entries[0].versions) == 0
+    # TODO: change to after Mesh 2.18 RC
+    assert len(attribute.entries) in {0, 1}
+    if len(attribute.entries) == 1:
+        assert len(attribute.entries[0].versions) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
In Mesh 2.18 there is a change that fixes returning non-empty attribute values when a versioned 1:1 link relation attribute doesn't have any entries. This change affects 2 tests in Mesh Python SDK.

Temporarily handle 2 behaviors: for new Mesh 2.18 and older Mesh versions.
Once we have available a nightly, engineering, etc. build of Mesh 2.18 ready, we'll switch to just one, new behavior.


