### PR TITLE
fix: Async `delete_object` was missing an `await` on an internal async call

### DIFF
--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -22,7 +22,7 @@ New features
 Changes
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- **Fixed:** Async `delete_object` was missing an `await` on an internal async call. :pull:`551`
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/volue/mesh/aio/_connection.py
+++ b/src/volue/mesh/aio/_connection.py
@@ -383,7 +383,7 @@ class Connection(_base_connection.Connection):
             self, target: Union[uuid.UUID, str, Object], recursive_delete: bool = False
         ) -> None:
             request = super()._prepare_delete_object_request(target, recursive_delete)
-            self.model_service.DeleteObject(request)
+            await self.model_service.DeleteObject(request)
 
         def forecast_functions(
             self,


### PR DESCRIPTION
It caused sporadic `test_mesh_objects_async` test fails.