### PR TITLE
chore: address ToDos in tests

### DIFF
--- a/src/volue/mesh/tests/test_relations.py
+++ b/src/volue/mesh/tests/test_relations.py
@@ -279,11 +279,7 @@ def test_update_versioned_one_to_one_link_relation_attribute_remove_all_versions
     )
 
     attribute = session.get_attribute(attribute_path)
-
-    # TODO: change to after Mesh 2.18 RC
-    assert len(attribute.entries) in {0, 1}
-    if len(attribute.entries) == 1:
-        assert len(attribute.entries[0].versions) == 0
+    assert len(attribute.entries) == 0
 
 
 @pytest.mark.database
@@ -661,11 +657,7 @@ async def test_update_versioned_one_to_one_link_relations_async(async_session):
     )
 
     attribute = await async_session.get_attribute(attribute_path)
-
-    # TODO: change to after Mesh 2.18 RC
-    assert len(attribute.entries) in {0, 1}
-    if len(attribute.entries) == 1:
-        assert len(attribute.entries[0].versions) == 0
+    assert len(attribute.entries) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
We switched to Mesh 2.18 with #555 