### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 60
 

--- a/.github/workflows/long_tests.yml
+++ b/.github/workflows/long_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 90
 

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 90
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ Prerequisites
 **************
 
 - Mesh server with gRPC enabled.
-- Python [3.9, 3.10, 3.11, 3.12]
+- Python [3.9, 3.10, 3.11, 3.12, 3.13]
 
 Getting help
 ---------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ If you don't have a GitHub user you can `join here <https://github.com/join>`_.
 Python
 **********
 
-Mesh Python SDK works with Python 3.9, 3.10, 3.11, and 3.12. Support for earlier and later versions is not guaranteed due to dependencies.
+Mesh Python SDK works with Python 3.9, 3.10, 3.11, 3.12 and 3.13. Support for earlier and later versions is not guaranteed due to dependencies.
 
 #. Download and install (Windows):
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -6,7 +6,7 @@ Here is a quick start guide to setup your first project using the library.
 Prerequisites quickstart
 **************************
 
-- Supported Python version [3.9 3.10, 3.11, 3.12].
+- Supported Python version [3.9 3.10, 3.11, 3.12, 3.13].
 - Running Volue Mesh server with gRPC enabled (either locally or on a different machine within your network).
 
 Installation quickstart

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -12,7 +12,7 @@ Compatible with
 ~~~~~~~~~~~~~~~~~~
 
 - Mesh server version >= 2.18 **(may change)**
-- Python [3.9, 3.10, 3.11, 3.12] **(may change)**
+- Python [3.9, 3.10, 3.11, 3.12, 3.13] **(may change)**
 
 New features
 ~~~~~~~~~~~~~~~~~~
@@ -20,6 +20,10 @@ New features
 - Support for availability events. :issue:`523`
   See :doc:`mesh_availability`.
 
+- Support for Python 3.13 :pull:`558`
+
+.. warning::
+    Python 3.9 support will dropped in the next Mesh Python SDK release.
 
 Changes
 ~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.13"
+python = ">=3.9, <3.14"
 grpcio = ">=1.37.0, <=1.66.1"
 pyarrow = ">=7.0.0"
 protobuf = ">=3.20.1, <=5.27.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.14"
-grpcio = ">=1.37.0, <=1.66.1"
+grpcio = ">=1.37.0, <=1.68.1"
 pyarrow = ">=7.0.0"
-protobuf = ">=3.20.1, <=5.27.2"
+protobuf = ">=3.20.1, <=5.28.1"
 winkerberos = { version = ">=0.9.1", markers = "sys_platform == 'win32'" }
 kerberos = { version = "^1.3.1", markers = "sys_platform == 'linux'" }
 bidict = ">=0.23.1"
@@ -57,7 +57,7 @@ python-dateutil = "^2.8.2"
 six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
-grpcio-tools = ">=1.37.0, <=1.66.1"
+grpcio-tools = ">=1.37.0, <=1.68.1"
 Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"
 rtd = "^1.2.3"
@@ -82,7 +82,7 @@ markers = [
 [build-system]
 requires = [
     "poetry-core>=1.8.5, <2.0.0",
-    "grpcio-tools>=1.37.0, <=1.66.1"
+    "grpcio-tools>=1.37.0, <=1.68.1"
 ]
 build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
There was a need to bump max grpcio-tools version. We had upper limit == 1.66.1, and since 1.66.2 there was support for 3.13.
As a result of this bump we need also to bump the corresponding protobuf version[^1].

Latest stable grpcio-tools version available in pip is 1.71.0, but it uses protobuf 5.29.0 - which was yanked,
See: 
* https://github.com/grpc/grpc/blob/v1.71.0/third_party/protobuf.patch
* https://pypi.org/project/protobuf/5.29.0/

Previous grpcio-tools version that uses other protobuf version is 1.68.1 and the corresponding protobuf is 5.28.1.
See: https://github.com/grpc/grpc/blob/v1.68.1/third_party/protobuf.patch

Resolves #541 

[^1]: See issue #503 for more info.
