### PR TITLE
limit versions of grpc related deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.14"
-grpcio = ">=1.37.0, <=1.68.1"
+grpcio = ">=1.37.0, <=1.67.1"
 pyarrow = ">=7.0.0"
-protobuf = ">=3.20.1, <=5.28.1"
+protobuf = ">=3.20.1, <=5.27.2"
 winkerberos = { version = ">=0.9.1", markers = "sys_platform == 'win32'" }
 kerberos = { version = "^1.3.1", markers = "sys_platform == 'linux'" }
 bidict = ">=0.23.1"
@@ -57,7 +57,7 @@ python-dateutil = "^2.8.2"
 six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
-grpcio-tools = ">=1.37.0, <=1.68.1"
+grpcio-tools = ">=1.37.0, <=1.67.1"
 Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"
 rtd = "^1.2.3"
@@ -82,7 +82,7 @@ markers = [
 [build-system]
 requires = [
     "poetry-core>=1.8.5, <2.0.0",
-    "grpcio-tools>=1.37.0, <=1.68.1"
+    "grpcio-tools>=1.37.0, <=1.67.1"
 ]
 build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
Starting from grpcio==1.68.0 in some cases the gRPC connection is aborted, e.g. when there are 2 concurrent sessions open and there is some pause/sleep between requests. This is causing the `test_sessions_lifetime_auto_extension` test to fail with:
```
"IOCP/Socket: Connection aborted (An established connection was aborted by the software in your host machine.
   -- 10053)"
```

I need to dig deeper to find out the root cause. For now revert to version(s) that seem to work correctly.