### PR TITLE
bump gRPC deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.14"
-grpcio = ">=1.37.0, <=1.67.1"
+grpcio = ">=1.37.0"
 pyarrow = ">=7.0.0"
-protobuf = ">=3.20.1, <=5.27.2"
+protobuf = ">=3.20.1"
 winkerberos = { version = ">=0.9.1", markers = "sys_platform == 'win32'" }
 kerberos = { version = "^1.3.1", markers = "sys_platform == 'linux'" }
 bidict = ">=0.23.1"
@@ -57,7 +57,7 @@ python-dateutil = "^2.8.2"
 six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
-grpcio-tools = ">=1.37.0, <=1.67.1"
+grpcio-tools = ">=1.37.0"
 Sphinx = ">=5.0.2"
 sphinx-rtd-theme = "^0.5.2"
 rtd = "^1.2.3"
@@ -82,7 +82,7 @@ markers = [
 [build-system]
 requires = [
     "poetry-core>=1.8.5, <2.0.0",
-    "grpcio-tools>=1.37.0, <=1.67.1"
+    "grpcio-tools>=1.37.0"
 ]
 build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
Since the issue from https://github.com/Volue-Public/energy-mesh-python/pull/559#issuecomment-3301446890 is fixed in new gRPC packages, remove the 1.67.1/5.27.2 limit in Mesh Python SDK. 

~Use similar approach as in https://github.com/Volue-Public/energy-mesh-python/pull/504.~
~grpc 1.75.0 uses protobuf 6.31.1. See: https://github.com/grpc/grpc/blob/v1.75.0/third_party/protobuf.patch~

[EDIT]

As for https://github.com/Volue-Public/energy-mesh-python/pull/504:
In newer protobuf versions we will be getting:
* warning logs:
  * if the protobuf major version for generated code is exactly one major version older than the runtime protobuf version
* errors[^1]:
  * if the protobuf version for generated code is newer than the runtime protobuf version
  * if the protobuf major version for generated code is more than one major version older than the runtime protobuf version

In such case removing the upper limit of grpcio and protobuf versions in pyproject.toml looks like an interesting option.
We will get only warnings if the latest protobuf version has major version higher than the one used in the latest grpcio. 
Then the user may downgrade manually to correct protobuf version.

FYI: @rudzkipl 

[^1]: Protobuf will raise error, so the Mesh Python SDK code won't work but return an error.