### PR TITLE
Add doc string for `create_physical_timeseries`

### DIFF
--- a/src/volue/mesh/_base_session.py
+++ b/src/volue/mesh/_base_session.py
@@ -671,13 +671,13 @@ class Session(abc.ABC):
         response will be "Resource/Path/To/Timeseries/Test_Timeseries".
 
         Args:
-            path: path of the new physical time series,
-                must begin and end with forward slashes.
+            path: path of the new physical time series.
+                Must begin and end with forward slashes.
             name: name of the new physical time series.
             curve_type: curve type of the new physical time series
             resolution: resolution of the new physical time series
-            unit_of_measurement: unit of measurement of the new physical time series,
-                the string must match an existing unit in Mesh.
+            unit_of_measurement: unit of measurement of the new physical time series.
+                It must match an existing unit in Mesh.
 
         Raises:
             grpc.RpcError: Error message raised if the gRPC request could not be completed.

--- a/src/volue/mesh/tests/test_timeseries_resource.py
+++ b/src/volue/mesh/tests/test_timeseries_resource.py
@@ -218,9 +218,9 @@ class TestCreatePhysicalTimeseries:
 
         self._verify_timeseries(timeseries, ts_init_data)
 
-        # Time series key is assigned by the database. Because in this test we
-        # are running Mesh without actual database the returned time series
-        # doesn't have a time series key assigned.
+        # The time series key is assigned by the database. Since in this test
+        # we are running Mesh without an actual database, the returned time
+        # series doesn't have a time series key assigned.
         assert timeseries.timeseries_key == 0
 
     def test_create_timeseries_with_non_existing_unit_of_measurement(


### PR DESCRIPTION
Add documentation: `create_physical_timeseries`.
The docstring can be nicely visualized by IDE.