### PR TITLE
Fix Mesh concepts link

### DIFF
--- a/docs/source/mesh_concepts.rst
+++ b/docs/source/mesh_concepts.rst
@@ -2,7 +2,7 @@
 Mesh concepts
 ==============
 
-Please refer to `Mesh documentation <https://volue-public.github.io/energy-smp-docs/latest/mesh/concepts/>`_
+Please refer to `Smart Power documentation <https://volue-public.github.io/energy-smp-docs/latest/>`_
 for a general description of Mesh concepts. Below are listed concepts with additional Mesh Python SDK specific information:
 
 .. toctree::


### PR DESCRIPTION
`/mesh/concepts/` doesn't have a separate page, but is just used for grouping purposes.
Link to main website of the SmP docs instead. The user will navigate manually to Mesh concepts - they are visible in the left side navbar.