### PR TITLE
fix: version compatibility doc formatting

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -218,6 +218,7 @@ Version compatibility
 =====================
 
 The Mesh Python SDK will perform the version compatibility check:
+
 - when connecting to the Mesh server for the synchronous code
 - when creating a Mesh session for the asynchronous code
 


### PR DESCRIPTION
rST needs an empty line before the list.

Before the change:
<img width="733" height="122" alt="image" src="https://github.com/user-attachments/assets/31cb6679-5470-4acd-9bd7-c897a1fe44a9" />

After:
<img width="530" height="172" alt="image" src="https://github.com/user-attachments/assets/a03617c7-a2ee-419f-b16b-38b84a197144" />
