### PR TITLE
Release version 1.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_preparation.yaml
+++ b/.github/ISSUE_TEMPLATE/release_preparation.yaml
@@ -12,6 +12,7 @@ body:
         - [ ] If the minimal supported Mesh version changed, then create in Mesh repository a new release in GitHub with official Mesh build for Mesh Python SDK.
               Switch to this version in Mesh Python SDK repo. Provide the new build number in comment.
         - [ ] If the minimal supported Mesh version changed, then update the `MINIMUM_SERVER_VERSION_STR` in `_version_compatibility.py`
+        - [ ] Update the Mesh Python SDK compatibility matrix: https://github.com/Volue-Public/energy-smp-docs/blob/main/docs/mesh/installation/MeshServiceInstallationGuide.md#mesh-python-sdk-compatibility-matrix.
         - [ ] Update https://github.com/Volue-Public/energy-mesh-python/blob/master/docs/source/versions.rst.
         - [ ] Update the Python SDK version to official one (without `-dev` suffix).
         - [ ] Release stable version (take previous release description template as base).

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -2,17 +2,21 @@ Versions
 --------
 
 Depending on the Mesh Server version you intend to communicate with a compatible version of Mesh Python SDK is needed.
+For detailed compatibility information, refer to the
+`compatibility matrix <https://volue-public.github.io/energy-smp-docs/latest/mesh/installation/MeshServiceInstallationGuide/#mesh-python-sdk-compatibility-matrix>`_.
 
-Mesh Python SDK version 1.14.0-dev
-**********************************
 
-This is the current master version.
+`Mesh Python SDK version 1.14.0 <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.14.0>`_
+***********************************************************************************************************
 
 Compatible with
 ~~~~~~~~~~~~~~~~~~
 
-- Mesh server version >= 2.18 **(may change)**
-- Python [3.9, 3.10, 3.11, 3.12, 3.13] **(may change)**
+- Mesh server version >= 2.18
+- Python [3.9, 3.10, 3.11, 3.12, 3.13]
+
+.. warning::
+    Python 3.9 support will dropped in one of the next Mesh Python SDK releases.
 
 New features
 ~~~~~~~~~~~~~~~~~~
@@ -23,11 +27,6 @@ New features
 - Mesh version compatibility mechanism.
   See documentation :ref:`Version compatibility` for more information. :pull:`583`
 
-Changes
-~~~~~~~~~~~~~~~~~~
-
-- TBA
-
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -35,7 +34,7 @@ See instructions at :ref:`Setup for users` and use the following:
 
 .. code-block:: bash
 
-    python -m pip install --force-reinstall git+https://github.com/Volue-Public/energy-mesh-python
+    python -m pip install git+https://github.com/Volue-Public/energy-mesh-python@v1.14.0
 
 
 `Mesh Python SDK version 1.13.0 <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.13.0>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volue.mesh"
-version = "1.14.0-dev"
+version = "1.14.0"
 description = ""
 license = "Proprietary"
 authors = ["Volue AS"]


### PR DESCRIPTION
* Update versions in the documentation
* Set version to stable 1.14 (no dev suffix)
* Add link to compatibility matrix in versions docs
* Add step with updating compatibility matrix in release issue template

For reference PR with 1.13 release: https://github.com/Volue-Public/energy-mesh-python/pull/561

