### PR TITLE
drop support for Python 3.9

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 60
 

--- a/.github/workflows/long_tests.yml
+++ b/.github/workflows/long_tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 90
 

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
       fail-fast: false
     timeout-minutes: 90
 
@@ -67,12 +67,6 @@ jobs:
           sudo apt-get install --yes software-properties-common
           sudo add-apt-repository --yes ppa:deadsnakes/ppa
           sudo apt-get install --yes python${{ matrix.python-version }}
-
-          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
-            sudo apt-get install --yes python${{ matrix.python-version }}-distutils
-          else
-            :  # not needed for newer Python versions
-          fi
 
           curl -sS https://bootstrap.pypa.io/get-pip.py | python${{ matrix.python-version }}
           sudo apt-get install --yes libkrb5-dev gcc

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ Prerequisites
 **************
 
 - Mesh server with gRPC enabled.
-- Python [3.9, 3.10, 3.11, 3.12, 3.13]
+- Python [3.10, 3.11, 3.12, 3.13]
 
 Getting help
 ---------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ If you don't have a GitHub user you can `join here <https://github.com/join>`_.
 Python
 **********
 
-Mesh Python SDK works with Python 3.9, 3.10, 3.11, 3.12 and 3.13. Support for earlier and later versions is not guaranteed due to dependencies.
+Mesh Python SDK works with Python 3.10, 3.11, 3.12 and 3.13. Support for earlier and later versions is not guaranteed due to dependencies.
 
 #. Download and install (Windows):
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -6,7 +6,7 @@ Here is a quick start guide to setup your first project using the library.
 Prerequisites quickstart
 **************************
 
-- Supported Python version [3.9 3.10, 3.11, 3.12, 3.13].
+- Supported Python version [3.10, 3.11, 3.12, 3.13].
 - Running Volue Mesh server with gRPC enabled (either locally or on a different machine within your network).
 
 Installation quickstart

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -13,10 +13,10 @@ Compatible with
 ~~~~~~~~~~~~~~~~~~
 
 - Mesh server version >= 2.18
-- Python [3.9, 3.10, 3.11, 3.12, 3.13]
+- Python [3.10, 3.11, 3.12, 3.13]
 
 .. warning::
-    Python 3.9 support will dropped in one of the next Mesh Python SDK releases.
+    Python 3.9 is no longer supported.
 
 New features
 ~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.14"
+python = ">=3.10, <3.14"
 grpcio = ">=1.37.0"
 pyarrow = ">=7.0.0"
 protobuf = ">=3.20.1"


### PR DESCRIPTION
We already announced dropping Python 3.9 with Mesh Python SDK 1.13.0 release.