### PR TITLE
Bump version and mark it as dev/pre-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volue.mesh"
-version = "1.15.0"
+version = "1.16.0-dev"
 description = ""
 license = "Proprietary"
 authors = ["Volue AS"]


### PR DESCRIPTION
Start 1.16.0-dev

Previous bump for reference: e2ef77456f6f5bd983a68e044a659e114c1d1c3a

Changes to versions.rst already done in e75030ea0f24ec1bd3d69ef477a8a6045cd6fcc5