### PR TITLE
Release version 1.16

### DIFF
--- a/.github/workflows/install_dev_env/action.yml
+++ b/.github/workflows/install_dev_env/action.yml
@@ -41,4 +41,4 @@ runs:
       id: download-mesh-server
       with:
         GITHUB_TOKEN: ${{ inputs.token }}
-        MESH_SERVICE_TAG: "v2.21.0.2796"
+        MESH_SERVICE_TAG: "v2.21.0.9"

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -41,7 +41,7 @@ jobs:
         id: download-mesh-server
         with:
           GITHUB_TOKEN: ${{ secrets.OAUTH_TOKEN }}
-          MESH_SERVICE_TAG: "v2.21.0.2796"
+          MESH_SERVICE_TAG: "v2.21.0.9"
 
       # Run one example before installing pytest packages and pandas
       # to check if all dependencies are installed together with Mesh Python SDK pip package.

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -6,27 +6,20 @@ For detailed compatibility information, refer to the
 `compatibility matrix <https://volue-public.github.io/energy-smp-docs/latest/mesh/installation/MeshServiceInstallationGuide/#mesh-python-sdk-compatibility-matrix>`_.
 
 
-Mesh Python SDK version 1.16.0-dev
-**********************************
-
-This is the current master version.
+`Mesh Python SDK version 1.16.0 <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.16.0>`_
+***********************************************************************************************************
 
 Compatible with
 ~~~~~~~~~~~~~~~~~~
 
-- Mesh server version >= 2.21.0 **(may change)**
-- Python [3.10, 3.11, 3.12, 3.13, 3.14] **(may change)**
+- Mesh server version >= 2.21.0
+- Python [3.10, 3.11, 3.12, 3.13, 3.14]
 
 New features
 ~~~~~~~~~~~~~~~~~~
 
 - Added support for zoned series. :issue:`587`
 - Added support for `MIN`, `MIN5` and `MIN10` resolutions. :pull:`617`
-
-Changes
-~~~~~~~~~~~~~~~~~~
-
-- TBA
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,7 +28,7 @@ See instructions at :ref:`Setup for users` and use the following:
 
 .. code-block:: bash
 
-    python -m pip install --force-reinstall git+https://github.com/Volue-Public/energy-mesh-python
+    python -m pip install git+https://github.com/Volue-Public/energy-mesh-python@v1.16.0
 
 
 `Mesh Python SDK version 1.15.0 <https://github.com/Volue-Public/energy-mesh-python/releases/tag/v1.15.0>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volue.mesh"
-version = "1.16.0-dev"
+version = "1.16.0"
 description = ""
 license = "Proprietary"
 authors = ["Volue AS"]


### PR DESCRIPTION
* Update versions in the documentation
* Set version to stable 1.16 (no dev suffix)
* Switch to 2.21.0 Mesh release version

For reference PR with 1.14 release: https://github.com/Volue-Public/energy-mesh-python/pull/594