### PR TITLE
Fix test error msg regex

### DIFF
--- a/src/volue/mesh/tests/test_mesh_objects.py
+++ b/src/volue/mesh/tests/test_mesh_objects.py
@@ -367,7 +367,9 @@ def test_create_and_update_object_with_invalid_target(session, invalid_target):
     Check that 'create_object' with invalid target (meaning incorrect owner
     attribute) and 'update_object' with invalid new owner attribute will throw.
     """
-    error_message_regex = "(O|owner of the object not found)|(Wrong type of the owner)"
+    error_message_regex = (
+        "(New o|O)wner of the object not found|Invalid type of the (new )?owner"
+    )
 
     with pytest.raises(grpc.RpcError, match=error_message_regex):
         session.create_object(invalid_target, "new_name")


### PR DESCRIPTION
Match:
* "New owner of the object not found"
* "Owner of the object not found"
* "Invalid type of the new owner"
* "Invalid type of the owner"

Previously, it was enough to just match on any capital `O` in the error string representation.