### PR TITLE
Conversion to time zone aware time series: example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, TESTS_FOLDER)
 # -- Project information -----------------------------------------------------
 
 project = "volue.mesh"
-copyright = "2025, Volue AS"
+copyright = "2026, Volue AS"
 author = "Volue AS"
 
 import re

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -159,7 +159,7 @@ Search calculation expressions
 .. literalinclude:: /../../src/volue/mesh/examples/search_calculation_expressions.py
    :language: python
 
-Time zone aware time series conversion
+Time zone-aware time series conversion
 **************************************
 .. literalinclude:: /../../src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
    :language: python

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -158,3 +158,8 @@ Search calculation expressions
 ******************************
 .. literalinclude:: /../../src/volue/mesh/examples/search_calculation_expressions.py
    :language: python
+
+Time zone aware time series conversion
+**************************************
+.. literalinclude:: /../../src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+   :language: python

--- a/docs/source/mesh_concepts.rst
+++ b/docs/source/mesh_concepts.rst
@@ -10,3 +10,4 @@ for a general description of Mesh concepts. Below are listed concepts with addit
 
    mesh_availability
    mesh_session
+   time_zone_aware_timeseries

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -4,7 +4,12 @@ Time zone aware timeseries
 
 
 The Mesh Python SDK allows for setting time zones
-through its time series creation and update APIs. For example:
+through its time series creation and update APIs:
+
+:py:meth:`volue.mesh.Connection.Session.create_physical_timeseries`
+:py:meth:`volue.mesh.Connection.Session.update_timeseries_resource_info`
+
+For example:
 
 .. code-block:: python
 

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -1,5 +1,5 @@
 ==========================
-Time zone aware timeseries
+Time zone-aware timeseries
 ==========================
 
 
@@ -29,4 +29,4 @@ See also the following examples:
 
 * :ref:`examples:Create physical time series`
 * :ref:`examples:Write time series`
-* :ref:`examples:Time zone aware time series conversion`
+* :ref:`examples:Time zone-aware time series conversion`

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -1,0 +1,7 @@
+==========================
+Time zone aware timeseries
+==========================
+
+See the :ref:`examples:Time zone aware time series conversion` example.
+
+

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -2,6 +2,26 @@
 Time zone aware timeseries
 ==========================
 
-See the :ref:`examples:Time zone aware time series conversion` example.
+
+The Mesh Python SDK allows for setting time zones
+through its time series creation and update APIs. For example:
+
+.. code-block:: python
+
+    result = session.create_physical_timeseries(
+        path="/Path/To/Test/Timeseries/",
+        name="Test_Timeseries",
+        curve_type=Timeseries.Curve.PIECEWISELINEAR,
+        resolution=Timeseries.Resolution.DAY,
+        unit_of_measurement="cm",
+        # time_zone is valid only if resolution is DAY or coarser
+        time_zone="Europe/Warsaw",
+    )
+    session.commit()
 
 
+See also the following examples:
+
+* :ref:`examples:Create physical time series`
+* :ref:`examples:Write time series`
+* :ref:`examples:Time zone aware time series conversion`

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -1,10 +1,11 @@
-from volue.mesh import Connection, Timeseries
 from datetime import datetime, timedelta
 
 import helpers
 import pyarrow as pa
 
-# This example shows how to convert two time series from time zone-naive to time zone-aware
+from volue.mesh import Connection, Timeseries
+
+# This example shows how to convert two daily time series from time zone-naive to time zone-aware
 # and back.
 #
 # Assuming we want to convert the time series with keys 1111 and 2222, we first use the
@@ -20,8 +21,10 @@ import pyarrow as pa
 # 2025-10-29 00:00
 # 2025-10-29 01:00
 # ...
-#
-# Before adding a time zone to this time series, we must remove the points at 01:00.
+# The values at midnight and 1AM are the same. If the values were different,
+# the user would need to make a decision which value should stay and adjust the script.
+# For this simple case, before adding a time zone to this time series,
+# we must remove the points at 01:00.
 #
 # The second time series (key: 2222) has its data unaligned to the midnight in the interval
 # [2025-10-25; 2026-03-28) (DB time zone):
@@ -63,13 +66,9 @@ DB_ZONE_MIDNIGHT_IN_UTC = 23
 DB_ZONE_1AM_IN_UTC = 0
 
 
-def fix_ts_1111(session: Connection.Session):
-    target = 1111
+def fix_ts_1111(session: Connection.Session, points: Timeseries):
     start = datetime(2025, 10, 26, 23, 0, 0)
     end = datetime(2026, 3, 27, 23, 0, 0)
-    points = session.read_timeseries_points(
-        target=target, start_time=start, end_time=end
-    )
 
     utc_date = points.arrow_table[0]
     flags = points.arrow_table[1]
@@ -81,7 +80,12 @@ def fix_ts_1111(session: Connection.Session):
 
     for point in zip(utc_date, flags, values):
         # Keep the points at DB time midnight.
-        if point[0].as_py().hour == DB_ZONE_MIDNIGHT_IN_UTC:
+        timestamp = point[0].as_py()
+        if (
+            timestamp >= start
+            and timestamp < end
+            and timestamp.hour == DB_ZONE_MIDNIGHT_IN_UTC
+        ):
             new_utc_date.append(point[0].as_py())
             new_flags.append(point[1])
             new_values.append(point[2])
@@ -90,7 +94,7 @@ def fix_ts_1111(session: Connection.Session):
 
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
     new_points = Timeseries(table=table, start_time=start, end_time=end)
-    new_points.timskey = target
+    new_points.timskey = points.timskey
 
     session.write_timeseries_points(new_points)
 
@@ -102,13 +106,9 @@ def fix_ts_1111(session: Connection.Session):
     session.rollback()
 
 
-def fix_ts_2222(session: Connection.Session):
-    target = 2222
+def fix_ts_2222(session: Connection.Session, points: Timeseries):
     start = datetime(2025, 10, 24, 23, 0, 0)
     end = datetime(2026, 3, 27, 23, 0, 0)
-    points = session.read_timeseries_points(
-        target=target, start_time=start, end_time=end
-    )
 
     utc_date = points.arrow_table[0]
     flags = points.arrow_table[1]
@@ -120,8 +120,13 @@ def fix_ts_2222(session: Connection.Session):
 
     for point in zip(utc_date, flags, values):
         # Move the points from 01:00 to 00:00 (DB time).
-        if point[0].as_py().hour == DB_ZONE_1AM_IN_UTC:
-            new_utc_date.append(point[0].as_py() + timedelta(hours=-1))
+        timestamp = point[0].as_py()
+        if (
+            timestamp >= start
+            and timestamp < end
+            and timestamp.hour == DB_ZONE_1AM_IN_UTC
+        ):
+            new_utc_date.append(point[0].as_py() - timedelta(hours=1))
             new_flags.append(point[1])
             new_values.append(point[2])
 
@@ -129,7 +134,7 @@ def fix_ts_2222(session: Connection.Session):
 
     table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
     new_points = Timeseries(table=table, start_time=start, end_time=end)
-    new_points.timskey = target
+    new_points.timskey = points.timskey
 
     session.write_timeseries_points(new_points)
 
@@ -141,22 +146,7 @@ def fix_ts_2222(session: Connection.Session):
     session.rollback()
 
 
-def validate_points_alignment(session: Connection.Session, ts_key: int):
-    START = datetime(year=1900, month=12, day=31, hour=23)
-    END = datetime(
-        START.year + 200,
-        START.month,
-        START.day,
-        START.hour,
-        START.minute,
-        START.second,
-        START.microsecond,
-        START.tzinfo,
-    )
-
-    points = session.read_timeseries_points(
-        target=ts_key, start_time=START, end_time=END
-    )
+def validate_points_alignment(points: Timeseries):
     if points.resolution is not Timeseries.Resolution.DAY:
         raise Exception(
             f"Time series (key {points.timskey}) resolution not equal to DAY: {points.resolution}"
@@ -170,7 +160,7 @@ def validate_points_alignment(session: Connection.Session, ts_key: int):
     for timestamp in utc_time:
         if timestamp.as_py().hour != DB_ZONE_MIDNIGHT_IN_UTC:
             print(
-                f"Time series key {ts_key}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
+                f"Time series key {points.timskey}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
             )
             aligned = False
             break
@@ -190,20 +180,36 @@ def convert_to_time_zone_naive(session: Connection.Session, ts_key: int):
 
 
 def main(address, tls_root_pem_cert):
+    # For production environments create connection using: with_tls, with_kerberos, or with_external_access_token, e.g.:
+    # connection = Connection.with_tls(address, tls_root_pem_cert)
     connection = Connection.insecure(address)
     with connection.create_session() as session:
+        # In perfect case all points of the time series to be converted to time zone-aware are correctly aligned.
+        # In such case, we can set the time zone and commit changes successfully. However, it may happen that the
+        # points are unaligned, especially around DST transitions. In this example we show 2 potential unalignment scenarios.
         try:
-            if validate_points_alignment(session=session, ts_key=TS_KEYS[0]) == False:
-                fix_ts_1111(session)
-                convert_to_time_zone_aware(session, TS_KEYS[0])
-                convert_to_time_zone_naive(session, TS_KEYS[0])
+            START = datetime(year=1900, month=12, day=31, hour=23)
+            END = datetime(year=2100, month=12, day=31, hour=23)
 
-            if validate_points_alignment(session=session, ts_key=TS_KEYS[1]) == False:
-                fix_ts_2222(session)
-                convert_to_time_zone_aware(session, TS_KEYS[1])
-                convert_to_time_zone_naive(session, TS_KEYS[1])
-        except:
-            print("Failed to convert the time series")
+            points = session.read_timeseries_points(
+                target=TS_KEYS[0], start_time=START, end_time=END
+            )
+
+            if not validate_points_alignment(points):
+                fix_ts_1111(session, points)
+            convert_to_time_zone_aware(session, TS_KEYS[0])
+            convert_to_time_zone_naive(session, TS_KEYS[0])
+
+            points = session.read_timeseries_points(
+                target=TS_KEYS[1], start_time=START, end_time=END
+            )
+
+            if not validate_points_alignment(points):
+                fix_ts_2222(session, points)
+            convert_to_time_zone_aware(session, TS_KEYS[1])
+            convert_to_time_zone_naive(session, TS_KEYS[1])
+        except Exception as e:
+            print(f"Failed to convert the time series: {e}")
 
 
 if __name__ == "__main__":

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -13,10 +13,6 @@ import pyarrow as pa
 # 3. If the time series points in the database are misaligned to the
 #    DB time zone, the conversion to time zone aware time series will fail
 #
-# To find all physical daily time zone naive time series in the database, one
-# can use the following SQL query: `SELECT tims_key FROM timeser WHERE tsin_key
-# = 111 AND time_zone is null AND rc_key is null;`
-#
 # Once we know all the time series we want to convert, let's find the ones with
 # misaligned data that need fixing before the conversion.  Use this function:
 # `validate_points_alignment(session, ts_key)` It will scan a range of points
@@ -38,24 +34,24 @@ import pyarrow as pa
 #    Adjust the saved points to the time zone and write them back.
 # 4. Fix the points, commit, set the time zone
 #    Create a script that fixes a specific time series case. 
-#    The time zone can be set once the data is correct.See 2 fix examples below.
+#    The time zone can be set once the data is correct. See 2 fix examples below.
 
 TS_KEYS = [
-    # This daily time series (key: 254335) has 2 points per day in the interval
+    # This daily time series (key: 1111) has 2 points per day in the interval
     # [2025-10-27; 2026-03-28) (DB time zone):
-    # 2025-10-27 12:00
+    # 2025-10-27 00:00
     # 2025-10-27 01:00
-    # 2025-10-28 12:00
+    # 2025-10-28 00:00
     # 2025-10-28 01:00
-    # 2025-10-29 12:00
+    # 2025-10-29 00:00
     # 2025-10-29 01:00
     # ...
     # The values and flags matchBefore adding a time zone to this time series,
     # remove the points at 01:00.
-    254335,
-    # This daily time series (key: 448438) data is unaligned to the DB time zone
+    1111,
+    # This daily time series (key: 2222) data is unaligned to the DB time zone
     # midnight in the interval [2025-10-25; 2026-03-28) (DB time zone):
-    # 2025-10-24 12:00
+    # 2025-10-24 00:00
     # 2025-10-25 01:00
     # 2025-10-26 01:00
     # 2025-10-27 01:00
@@ -63,12 +59,12 @@ TS_KEYS = [
     # ...
     # Before adding a time zone to this time series, shift the timestamps one
     # hour back in that interval.
-    448438
+    2222
 ]
 
 
-def fix_ts_254335(session: Connection.Session):
-    target = 254335
+def fix_ts_1111(session: Connection.Session):
+    target = 1111
     start = datetime(2025, 10, 24, 23, 0, 0)
     end = datetime(2026, 3, 27, 23, 0, 0)
     points = session.read_timeseries_points(
@@ -106,8 +102,8 @@ def fix_ts_254335(session: Connection.Session):
 
 
 
-def fix_ts_448438(session: Connection.Session):
-    target = 448438
+def fix_ts_2222(session: Connection.Session):
+    target = 2222
     start = datetime(2025, 10, 24, 23, 0, 0)
     end = datetime(2026, 3, 27, 23, 0, 0)
     points = session.read_timeseries_points(
@@ -192,11 +188,11 @@ def main(address, tls_root_pem_cert):
     connection = Connection.insecure(address)
     with connection.create_session() as session:
         if validate_points_alignment(session=session, ts_key=TS_KEYS[0]) == False:
-            fix_ts_254335(session)
+            fix_ts_1111(session)
             convert_to_time_zone_aware(session, TS_KEYS[0])
 
         if validate_points_alignment(session=session, ts_key=TS_KEYS[1]) == False:
-            fix_ts_448438(session)
+            fix_ts_2222(session)
             convert_to_time_zone_aware(session, TS_KEYS[1])
 
 

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -4,63 +4,58 @@ from datetime import datetime, timedelta
 import helpers
 import pyarrow as pa
 
-# This file is an example of a transformation from time zone naive time
-# series to time zone aware time series and back. Several things to note:
-# 1. Only time series with resolution of DAY or coarser can be converted to
-#    time zone aware time series
-# 2. Time series with edits cannot be converted to time zone aware
-#    time series
-# 3. If the time series points in the database are misaligned to the
-#    DB time zone midnight, the conversion to time zone aware time series
-#    will fail
+# This example shows how to convert two time series from time zone-naive to time zone-aware
+# and back.
 #
-# Once we know all the time series we want to convert, let's find the ones with
-# misaligned data that need fixing before the conversion. Use this function:
-# `validate_points_alignment(session, ts_key)`. It will scan a range of points
-# and stop on the first misaligned point. The log will point to the misaligned
-# timestamp.
+# Assuming we want to convert the time series with keys 1111 and 2222, we first use the
+# `validate_points_alignment` function to scan a range of points on each series and verify whether
+# their points are correctly aligned. In this case, both of these time series have points that need
+# to be adjusted before we can perform the conversion:
 #
-# Now, the user needs to peek in the DB and assess how to fix the data. The fix
-# depends on the way the data is broken and what the data writer intended.
-# There are several options:
-# 1. Delete old points before conversion
+# The first time series (key 1111) has 2 points per day in the interval [2025-10-27; 2026-03-28) (DB time zone):
+# 2025-10-27 00:00
+# 2025-10-27 01:00
+# 2025-10-28 00:00
+# 2025-10-28 01:00
+# 2025-10-29 00:00
+# 2025-10-29 01:00
+# ...
+#
+# Before adding a time zone to this time series, we must remove the points at 01:00.
+#
+# The second time series (key: 2222) has its data unaligned to the midnight in the interval
+# [2025-10-25; 2026-03-28) (DB time zone):
+# 2025-10-24 00:00
+# 2025-10-25 01:00
+# 2025-10-26 01:00
+# 2025-10-27 01:00
+# 2025-10-28 01:00
+# ...
+#
+# Before adding a time zone to this time series, we must shift the timestamps one hour back in that interval.
+#
+# We now need to decide on how to fix the time series for conversion. The method we choose for this
+# will depend on how the points are misaligned, and the intention of the user who originally wrote
+# them:
+#
+# 1. Delete the old points before conversion
 #    Simple approach that works when the historical data is not important.
-# 2. Create a new time zone aware time series
+# 2. Create a new time zone-aware time series
 #    Simple approach, but the old time series resource needs to be replaced
 #    with a new one in the model. Additionally, if some calculation expressions
 #    refer to the time series directly, they have to be updated.
 # 3. Save-Remove-Adjust-Write
 #    Save the old points to some storage (other time series, file, etc...).
-#    Remove the points from the old time series. Once it's empty, set the time zone.
+#    Remove the points from the old time series. Once it's empty, set the time zone and commit.
 #    Adjust the saved points to the time zone and write them back.
 # 4. Fix the points, commit, set the time zone
 #    Create a script that fixes a specific time series case.
-#    The time zone can be set once the data is correct. See 2 fix examples below.
-#    THEY MAY NOT APPLY TO YOUR CASE. Be sure to examine the data and adjust the script.
+#    The time zone can be set once the data is correct.
+#
+# For this example, we will use the last method.
 
 TS_KEYS = [
-    # This daily time series (key: 1111) has 2 points per day in the interval
-    # [2025-10-27; 2026-03-28) (DB time zone):
-    # 2025-10-27 00:00
-    # 2025-10-27 01:00
-    # 2025-10-28 00:00
-    # 2025-10-28 01:00
-    # 2025-10-29 00:00
-    # 2025-10-29 01:00
-    # ...
-    # Before adding a time zone to this time series,
-    # remove the points at 01:00.
     1111,
-    # This daily time series (key: 2222) data is unaligned to the DB time zone
-    # midnight in the interval [2025-10-25; 2026-03-28) (DB time zone):
-    # 2025-10-24 00:00
-    # 2025-10-25 01:00
-    # 2025-10-26 01:00
-    # 2025-10-27 01:00
-    # 2025-10-28 01:00
-    # ...
-    # Before adding a time zone to this time series, shift the timestamps one
-    # hour back in that interval.
     2222,
 ]
 

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -86,7 +86,7 @@ def fix_ts_1111(session: Connection.Session, points: Timeseries):
             and timestamp < end
             and timestamp.hour == DB_ZONE_MIDNIGHT_IN_UTC
         ):
-            new_utc_date.append(point[0].as_py())
+            new_utc_date.append(timestamp)
             new_flags.append(point[1])
             new_values.append(point[2])
 
@@ -126,7 +126,7 @@ def fix_ts_2222(session: Connection.Session, points: Timeseries):
             and timestamp < end
             and timestamp.hour == DB_ZONE_1AM_IN_UTC
         ):
-            new_utc_date.append(point[0].as_py() - timedelta(hours=1))
+            new_utc_date.append(timestamp - timedelta(hours=1))
             new_flags.append(point[1])
             new_values.append(point[2])
 

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -70,7 +70,7 @@ DB_ZONE_1AM_IN_UTC = 0
 
 def fix_ts_1111(session: Connection.Session):
     target = 1111
-    start = datetime(2025, 10, 24, 23, 0, 0)
+    start = datetime(2025, 10, 26, 23, 0, 0)
     end = datetime(2026, 3, 27, 23, 0, 0)
     points = session.read_timeseries_points(
         target=target, start_time=start, end_time=end

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -26,7 +26,7 @@ from volue.mesh import Connection, Timeseries
 # For this simple case, before adding a time zone to this time series,
 # we must remove the points at 01:00.
 #
-# The second time series (key: 2222) has its data unaligned to the midnight in the interval
+# The second time series (key: 2222) has its data misaligned to the midnight in the interval
 # [2025-10-25; 2026-03-28) (DB time zone):
 # 2025-10-24 00:00
 # 2025-10-25 01:00
@@ -149,7 +149,7 @@ def fix_ts_2222(session: Connection.Session, points: Timeseries):
 def validate_points_alignment(points: Timeseries):
     if points.resolution is not Timeseries.Resolution.DAY:
         raise Exception(
-            f"Time series (key {points.timskey}) resolution not equal to DAY: {points.resolution}"
+            f"time series (key {points.timskey}) resolution not equal to DAY: {points.resolution}"
         )
 
     utc_time = points.arrow_table[0]
@@ -160,7 +160,7 @@ def validate_points_alignment(points: Timeseries):
     for timestamp in utc_time:
         if timestamp.as_py().hour != DB_ZONE_MIDNIGHT_IN_UTC:
             print(
-                f"Time series key {points.timskey}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
+                f"time series key {points.timskey}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
             )
             aligned = False
             break
@@ -184,15 +184,15 @@ def main(address, tls_root_pem_cert):
     # connection = Connection.with_tls(address, tls_root_pem_cert)
     connection = Connection.insecure(address)
     with connection.create_session() as session:
-        # In perfect case all points of the time series to be converted to time zone-aware are correctly aligned.
-        # In such case, we can set the time zone and commit changes successfully. However, it may happen that the
-        # points are unaligned, especially around DST transitions. In this example we show 2 potential unalignment scenarios.
+        # In the perfect case, all points in the time series are correctly aligned, and we can
+        # simply set the time zone and commit. However, points may be misaligned, for example
+        # around DST transitions. This example covers 2 potential misalignment scenarios.
         try:
-            START = datetime(year=1900, month=12, day=31, hour=23)
-            END = datetime(year=2100, month=12, day=31, hour=23)
+            start = datetime(year=1900, month=12, day=31, hour=23)
+            end = datetime(year=2100, month=12, day=31, hour=23)
 
             points = session.read_timeseries_points(
-                target=TS_KEYS[0], start_time=START, end_time=END
+                target=TS_KEYS[0], start_time=start, end_time=end
             )
 
             if not validate_points_alignment(points):
@@ -201,7 +201,7 @@ def main(address, tls_root_pem_cert):
             convert_to_time_zone_naive(session, TS_KEYS[0])
 
             points = session.read_timeseries_points(
-                target=TS_KEYS[1], start_time=START, end_time=END
+                target=TS_KEYS[1], start_time=start, end_time=end
             )
 
             if not validate_points_alignment(points):
@@ -209,7 +209,7 @@ def main(address, tls_root_pem_cert):
             convert_to_time_zone_aware(session, TS_KEYS[1])
             convert_to_time_zone_naive(session, TS_KEYS[1])
         except Exception as e:
-            print(f"Failed to convert the time series: {e}")
+            print(f"failed to convert the time series: {e}")
 
 
 if __name__ == "__main__":

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -82,7 +82,7 @@ def fix_ts_1111(session: Connection.Session):
 
     for point in zip(utc_date, flags, values):
         # Keep the points at DB time midnight.
-        # if point[0].as_py().hour == 23:
+        if point[0].as_py().hour == 23:
             new_utc_date.append(point[0].as_py())
             new_flags.append(point[1])
             new_values.append(point[2])

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -11,7 +11,8 @@ import pyarrow as pa
 # 2. Time series with edits can not be converted to time zone aware
 #    time series
 # 3. If the time series points in the database are misaligned to the
-#    DB time zone, the conversion to time zone aware time series will fail
+#    DB time zone midnight, the conversion to time zone aware time series
+#    will fail
 #
 # Once we know all the time series we want to convert, let's find the ones with
 # misaligned data that need fixing before the conversion.  Use this function:
@@ -24,7 +25,7 @@ import pyarrow as pa
 # writer. There are several options:
 # 1. Delete old points before conversion
 #    Simple approach that works when the historical data is not important.
-# 2. Create a new time series
+# 2. Create a new time zone aware time series
 #    Simple approach, but the old time series resource needs to be replaced
 #    with a new one in the model. Additionally, if some calculation expressions
 #    refer to the time series directly, they have to be updated.

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -5,24 +5,24 @@ import helpers
 import pyarrow as pa
 
 # This file is an example of a transformation from time zone naive time
-# series to time zone aware time series.  Several things to note: 
+# series to time zone aware time series. Several things to note:
 # 1. Only time series with resolution of DAY or coarser can be converted to
 #    time zone aware time series 
-# 2. Time series with edits can not be converted to time zone aware
+# 2. Time series with edits cannot be converted to time zone aware
 #    time series
 # 3. If the time series points in the database are misaligned to the
 #    DB time zone midnight, the conversion to time zone aware time series
 #    will fail
 #
 # Once we know all the time series we want to convert, let's find the ones with
-# misaligned data that need fixing before the conversion.  Use this function:
-# `validate_points_alignment(session, ts_key)` It will scan a range of points
-# and stop on the first misaligned point.  The log will point to the misaligned
+# misaligned data that need fixing before the conversion. Use this function:
+# `validate_points_alignment(session, ts_key)`. It will scan a range of points
+# and stop on the first misaligned point. The log will point to the misaligned
 # timestamp.
 #
 # Now, the user needs to peek in the DB and assess how to fix the data. The fix
-# depends on the way the data is broken and what was the intention of the data
-# writer. There are several options:
+# depends on the way the data is broken and what the data writer intended.
+# There are several options:
 # 1. Delete old points before conversion
 #    Simple approach that works when the historical data is not important.
 # 2. Create a new time zone aware time series
@@ -36,6 +36,7 @@ import pyarrow as pa
 # 4. Fix the points, commit, set the time zone
 #    Create a script that fixes a specific time series case. 
 #    The time zone can be set once the data is correct. See 2 fix examples below.
+#    THEY MAY NOT APPLY TO YOUR CASE. Be sure to examine the data and adjust the script.
 
 TS_KEYS = [
     # This daily time series (key: 1111) has 2 points per day in the interval
@@ -47,7 +48,7 @@ TS_KEYS = [
     # 2025-10-29 00:00
     # 2025-10-29 01:00
     # ...
-    # The values and flags matchBefore adding a time zone to this time series,
+    # Before adding a time zone to this time series,
     # remove the points at 01:00.
     1111,
     # This daily time series (key: 2222) data is unaligned to the DB time zone

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -1,0 +1,192 @@
+from volue.mesh import Connection, Timeseries
+from datetime import datetime, timedelta
+
+import helpers
+import pyarrow as pa
+
+# This file is an example of a transformation from time zone naive time
+# series to time zone aware time series.  Several things to note: 
+# 1. Only time series with resolution of DAY or coarser can be converted to
+#    time zone aware time series 
+# 2. Time series with edits can not be converted to time zone aware
+#    time series
+# 3. If the time series points in the database are misaligned to the
+#    DB time zone, the conversion to time zone aware time series will fail
+#
+# To find all physical daily time zone naive time series in the database, one
+# can use the following SQL query: `SELECT tims_key FROM timeser WHERE tsin_key
+# = 111 AND time_zone is null AND rc_key is null;`
+#
+# Once we know all the time series we want to convert, let's find the ones with
+# misaligned data that need fixing before the conversion.  Use this function:
+# `validate_points_alignment(session, ts_key)` It will scan a range of points
+# and stop on the first misaligned point.  The log will point to the misaligned
+# timestamp.
+#
+# Now, the user needs to peek in the DB and assess how to fix the data. The fix
+# depends on the way the data is broken and what was the intention of the data
+# writer.  See 2 fix examples below.
+
+TS_KEYS = [
+    # This daily time series (key: 448438) data is unaligned to the DB time zone
+    # midnight in the interval [2025-10-25; 2026-03-28) (DB time zone):
+    # 2025-10-24 12:00
+    # 2025-10-25 01:00
+    # 2025-10-26 01:00
+    # 2025-10-27 01:00
+    # 2025-10-28 01:00
+    # ...
+    # Before adding a time zone to this time series, shift the timestamps one
+    # hour back in that interval.
+    448438,
+    # This daily time series (key: 254335) has 2 points per day in the interval
+    # [2025-10-27; 2026-03-28) (DB time zone):
+    # 2025-10-27 12:00
+    # 2025-10-27 01:00
+    # 2025-10-28 12:00
+    # 2025-10-28 01:00
+    # 2025-10-29 12:00
+    # 2025-10-29 01:00
+    # ...
+    # The values and flags matchBefore adding a time zone to this time series,
+    # remove the points at 01:00.
+    254335,
+]
+
+
+def fix_ts_254335(session: Connection.Session):
+    target = 254335
+    start = datetime(2025, 10, 24, 23, 0, 0)
+    end = datetime(2026, 3, 27, 23, 0, 0)
+    points = session.read_timeseries_points(
+        target=target, start_time=start, end_time=end
+    )
+
+    utc_date = points.arrow_table[0]
+    flags = points.arrow_table[1]
+    values = points.arrow_table[2]
+
+    new_utc_date = []
+    new_flags = []
+    new_values = []
+
+    for point in zip(utc_date, flags, values):
+        if point[0].as_py().hour == 23:
+            new_utc_date.append(point[0])
+            new_flags.append(point[1])
+            new_values.append(point[2])
+
+    arrays = [pa.array(new_utc_date), pa.array(new_flags), pa.array(new_values)]
+
+    table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
+    new_points = Timeseries(table=table, start_time=start, end_time=end)
+    new_points.timskey = target
+
+    session.write_timeseries_points(new_points)
+
+    # Read the points again and visually confirm the data is correct.
+    # points_not_saved = session.read_timeseries_points(target=target, start_time=start, end_time=end)
+    # print(points_not_saved.arrow_table.to_pandas())
+    # If the result is fine - commit.
+    # session.commit()
+    session.rollback()
+
+
+
+def fix_ts_448438(session: Connection.Session):
+    target = 448438
+    start = datetime(2025, 10, 24, 23, 0, 0)
+    end = datetime(2026, 3, 27, 23, 0, 0)
+    points = session.read_timeseries_points(
+        target=target, start_time=start, end_time=end
+    )
+
+    utc_date = points.arrow_table[0]
+    flags = points.arrow_table[1]
+    values = points.arrow_table[2]
+
+    new_utc_date = []
+    new_flags = []
+    new_values = []
+
+    for point in zip(utc_date, flags, values):
+        if point[0].as_py().hour == 0:
+            new_utc_date.append(point[0].as_py() + timedelta(hours=-1))
+            new_flags.append(point[1])
+            new_values.append(point[2])
+
+    arrays = [pa.array(new_utc_date), pa.array(new_flags), pa.array(new_values)]
+
+    table = pa.Table.from_arrays(arrays, schema=Timeseries.schema)
+    new_points = Timeseries(table=table, start_time=start, end_time=end)
+    new_points.timskey = target
+
+    session.write_timeseries_points(new_points)
+
+    # Read the points again and visually confirm the data is correct.
+    # points_not_saved = session.read_timeseries_points(target=target, start_time=start, end_time=end)
+    # print(points_not_saved.arrow_table.to_pandas())
+    # If the result is fine - commit.
+    # session.commit()
+    session.rollback()
+
+
+
+def validate_points_alignment(session: Connection.Session, ts_key: int):
+    START = datetime(year=1900, month=12, day=31, hour=23)
+    END = datetime(
+        START.year + 200,
+        START.month,
+        START.day,
+        START.hour,
+        START.minute,
+        START.second,
+        START.microsecond,
+        START.tzinfo,
+    )
+
+    points = session.read_timeseries_points(
+        target=ts_key, start_time=START, end_time=END
+    )
+    if points.resolution is not Timeseries.Resolution.DAY:
+        raise Exception(
+            f"Time series (key {points.timskey}) resolution not equal to DAY: {points.resolution}"
+        )
+
+    utc_time = points.arrow_table[0]
+    if len(utc_time) == 0:
+        raise Exception("Unexpected empty segment")
+
+    aligned = True
+    for timestamp in utc_time:
+        if timestamp.as_py().hour != 23:
+            print(
+                f"Time series key {ts_key}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
+            )
+            aligned = False
+            break
+    return aligned
+
+
+def convert_to_time_zone_aware(session: Connection.Session, ts_key: int):
+    session.update_timeseries_resource_info(
+        timeseries_key=ts_key, new_time_zone="Europe/Warsaw"
+    )
+    session.commit()
+
+
+def main(address, tls_root_pem_cert):
+    connection = Connection.insecure(address)
+    with connection.create_session() as session:
+        if validate_points_alignment(session=session, ts_key=TS_KEYS[0]) == False:
+            fix_ts_254335(session)
+            convert_to_time_zone_aware(session, TS_KEYS[0])
+
+        if validate_points_alignment(session=session, ts_key=TS_KEYS[1]) == False:
+            fix_ts_448438(session)
+            convert_to_time_zone_aware(session, TS_KEYS[1])
+
+
+if __name__ == "__main__":
+    address, tls_root_pem_cert = helpers.get_connection_info()
+    main(address, tls_root_pem_cert)

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -5,9 +5,9 @@ import helpers
 import pyarrow as pa
 
 # This file is an example of a transformation from time zone naive time
-# series to time zone aware time series. Several things to note:
+# series to time zone aware time series and back. Several things to note:
 # 1. Only time series with resolution of DAY or coarser can be converted to
-#    time zone aware time series 
+#    time zone aware time series
 # 2. Time series with edits cannot be converted to time zone aware
 #    time series
 # 3. If the time series points in the database are misaligned to the
@@ -34,7 +34,7 @@ import pyarrow as pa
 #    Remove the points from the old time series. Once it's empty, set the time zone.
 #    Adjust the saved points to the time zone and write them back.
 # 4. Fix the points, commit, set the time zone
-#    Create a script that fixes a specific time series case. 
+#    Create a script that fixes a specific time series case.
 #    The time zone can be set once the data is correct. See 2 fix examples below.
 #    THEY MAY NOT APPLY TO YOUR CASE. Be sure to examine the data and adjust the script.
 
@@ -61,8 +61,11 @@ TS_KEYS = [
     # ...
     # Before adding a time zone to this time series, shift the timestamps one
     # hour back in that interval.
-    2222
+    2222,
 ]
+
+DB_ZONE_MIDNIGHT_IN_UTC = 23
+DB_ZONE_1AM_IN_UTC = 0
 
 
 def fix_ts_1111(session: Connection.Session):
@@ -83,7 +86,7 @@ def fix_ts_1111(session: Connection.Session):
 
     for point in zip(utc_date, flags, values):
         # Keep the points at DB time midnight.
-        if point[0].as_py().hour == 23:
+        if point[0].as_py().hour == DB_ZONE_MIDNIGHT_IN_UTC:
             new_utc_date.append(point[0].as_py())
             new_flags.append(point[1])
             new_values.append(point[2])
@@ -104,7 +107,6 @@ def fix_ts_1111(session: Connection.Session):
     session.rollback()
 
 
-
 def fix_ts_2222(session: Connection.Session):
     target = 2222
     start = datetime(2025, 10, 24, 23, 0, 0)
@@ -123,7 +125,7 @@ def fix_ts_2222(session: Connection.Session):
 
     for point in zip(utc_date, flags, values):
         # Move the points from 01:00 to 00:00 (DB time).
-        if point[0].as_py().hour == 0:
+        if point[0].as_py().hour == DB_ZONE_1AM_IN_UTC:
             new_utc_date.append(point[0].as_py() + timedelta(hours=-1))
             new_flags.append(point[1])
             new_values.append(point[2])
@@ -142,7 +144,6 @@ def fix_ts_2222(session: Connection.Session):
     # If the result is fine - commit.
     # session.commit()
     session.rollback()
-
 
 
 def validate_points_alignment(session: Connection.Session, ts_key: int):
@@ -172,7 +173,7 @@ def validate_points_alignment(session: Connection.Session, ts_key: int):
 
     aligned = True
     for timestamp in utc_time:
-        if timestamp.as_py().hour != 23:
+        if timestamp.as_py().hour != DB_ZONE_MIDNIGHT_IN_UTC:
             print(
                 f"Time series key {ts_key}: the timestamp {timestamp.as_py()} is not aligned to the DB time zone midnight"
             )
@@ -188,16 +189,26 @@ def convert_to_time_zone_aware(session: Connection.Session, ts_key: int):
     session.commit()
 
 
+def convert_to_time_zone_naive(session: Connection.Session, ts_key: int):
+    session.update_timeseries_resource_info(timeseries_key=ts_key, new_time_zone="")
+    session.commit()
+
+
 def main(address, tls_root_pem_cert):
     connection = Connection.insecure(address)
     with connection.create_session() as session:
-        if validate_points_alignment(session=session, ts_key=TS_KEYS[0]) == False:
-            fix_ts_1111(session)
-            convert_to_time_zone_aware(session, TS_KEYS[0])
+        try:
+            if validate_points_alignment(session=session, ts_key=TS_KEYS[0]) == False:
+                fix_ts_1111(session)
+                convert_to_time_zone_aware(session, TS_KEYS[0])
+                convert_to_time_zone_naive(session, TS_KEYS[0])
 
-        if validate_points_alignment(session=session, ts_key=TS_KEYS[1]) == False:
-            fix_ts_2222(session)
-            convert_to_time_zone_aware(session, TS_KEYS[1])
+            if validate_points_alignment(session=session, ts_key=TS_KEYS[1]) == False:
+                fix_ts_2222(session)
+                convert_to_time_zone_aware(session, TS_KEYS[1])
+                convert_to_time_zone_naive(session, TS_KEYS[1])
+        except:
+            print("Failed to convert the time series")
 
 
 if __name__ == "__main__":

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -25,20 +25,22 @@ import pyarrow as pa
 #
 # Now, the user needs to peek in the DB and assess how to fix the data. The fix
 # depends on the way the data is broken and what was the intention of the data
-# writer.  See 2 fix examples below.
+# writer. There are several options:
+# 1. Delete old points before conversion
+#    Simple approach that works when the historical data is not important.
+# 2. Create a new time series
+#    Simple approach, but the old time series resource needs to be replaced
+#    with a new one in the model. Additionally, if some calculation expressions
+#    refer to the time series directly, they have to be updated.
+# 3. Save-Remove-Adjust-Write
+#    Save the old points to some storage (other time series, file, etc...).
+#    Remove the points from the old time series. Once it's empty, set the time zone.
+#    Adjust the saved points to the time zone and write them back.
+# 4. Fix the points, commit, set the time zone
+#    Create a script that fixes a specific time series case. 
+#    The time zone can be set once the data is correct.See 2 fix examples below.
 
 TS_KEYS = [
-    # This daily time series (key: 448438) data is unaligned to the DB time zone
-    # midnight in the interval [2025-10-25; 2026-03-28) (DB time zone):
-    # 2025-10-24 12:00
-    # 2025-10-25 01:00
-    # 2025-10-26 01:00
-    # 2025-10-27 01:00
-    # 2025-10-28 01:00
-    # ...
-    # Before adding a time zone to this time series, shift the timestamps one
-    # hour back in that interval.
-    448438,
     # This daily time series (key: 254335) has 2 points per day in the interval
     # [2025-10-27; 2026-03-28) (DB time zone):
     # 2025-10-27 12:00
@@ -51,6 +53,17 @@ TS_KEYS = [
     # The values and flags matchBefore adding a time zone to this time series,
     # remove the points at 01:00.
     254335,
+    # This daily time series (key: 448438) data is unaligned to the DB time zone
+    # midnight in the interval [2025-10-25; 2026-03-28) (DB time zone):
+    # 2025-10-24 12:00
+    # 2025-10-25 01:00
+    # 2025-10-26 01:00
+    # 2025-10-27 01:00
+    # 2025-10-28 01:00
+    # ...
+    # Before adding a time zone to this time series, shift the timestamps one
+    # hour back in that interval.
+    448438
 ]
 
 

--- a/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
+++ b/src/volue/mesh/examples/convert_to_time_zone_aware_timeseries.py
@@ -81,8 +81,9 @@ def fix_ts_1111(session: Connection.Session):
     new_values = []
 
     for point in zip(utc_date, flags, values):
-        if point[0].as_py().hour == 23:
-            new_utc_date.append(point[0])
+        # Keep the points at DB time midnight.
+        # if point[0].as_py().hour == 23:
+            new_utc_date.append(point[0].as_py())
             new_flags.append(point[1])
             new_values.append(point[2])
 
@@ -120,6 +121,7 @@ def fix_ts_2222(session: Connection.Session):
     new_values = []
 
     for point in zip(utc_date, flags, values):
+        # Move the points from 01:00 to 00:00 (DB time).
         if point[0].as_py().hour == 0:
             new_utc_date.append(point[0].as_py() + timedelta(hours=-1))
             new_flags.append(point[1])

--- a/src/volue/mesh/examples/helpers.py
+++ b/src/volue/mesh/examples/helpers.py
@@ -3,7 +3,7 @@ import sys
 
 def get_connection_info():
     """Helper function to set hand over connection info to examples."""
-    address = "localhost:50001"
+    address = "localhost:50051"
     tls_root_pem_cert = ""
 
     if len(sys.argv) > 1:

--- a/src/volue/mesh/examples/helpers.py
+++ b/src/volue/mesh/examples/helpers.py
@@ -3,7 +3,7 @@ import sys
 
 def get_connection_info():
     """Helper function to set hand over connection info to examples."""
-    address = "localhost:50051"
+    address = "localhost:50001"
     tls_root_pem_cert = ""
 
     if len(sys.argv) > 1:


### PR DESCRIPTION
Add an example script

- The script description contains 2 situations found in one of the internal DBs where points were misaligned to the DB zone
- The script has a validation function which should be ran before attempting to convert ts to time zone aware
- The script fixes the situations presented in the description and converts the ts to time zone aware and back
- Add a documentation page on time zone aware ts with a reference to the example

Refers to https://github.com/Volue/energy-mesh/issues/8332