### PR TITLE
transform changes

### DIFF
--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -34,9 +34,9 @@ See also the following examples:
 * :ref:`examples:Time zone-aware time series conversion`
 
 
-Transforming time zone-aware time series
-========================================
-
+Transforming time zone-aware time series
+========================================
+
 When transforming a time zone-aware time series using
 :py:meth:`volue.mesh.calc.transform.TransformFunctions.transform`, the
 ``timezone`` argument must be set to ``None``.

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -2,6 +2,8 @@
 Time zone-aware time series
 ===========================
 
+Please refer to `Mesh documentation <https://volue-public.github.io/energy-smp-docs/latest/mesh/concepts/time-series/time-zone-aware-time-series/>`_
+for a general description of time zone-aware time series in Mesh.
 
 The Mesh Python SDK allows for setting time zones
 through its time series creation and update APIs:
@@ -20,7 +22,7 @@ For example:
         resolution=Timeseries.Resolution.DAY,
         unit_of_measurement="cm",
         # time_zone is valid only if resolution is DAY or coarser
-        time_zone="Europe/Warsaw",
+        time_zone="Europe/Warsaw"
     )
     session.commit()
 
@@ -30,3 +32,31 @@ See also the following examples:
 * :ref:`examples:Create physical time series`
 * :ref:`examples:Write time series`
 * :ref:`examples:Time zone-aware time series conversion`
+
+
+Transforming time zone-aware time series 2
+===========================================
+
+
+When transforming a time zone-aware time series using
+:py:meth:`volue.mesh.calc.transform.TransformFunctions.transform`, the
+``timezone`` argument must be set to ``None``.
+
+.. code-block:: python
+
+    result = session.read_timeseries_points(
+        target=ts_attribute,
+        start_time=start,
+        end_time=end,
+    ).transform(
+        resolution=Timeseries.Resolution.HOUR,
+        method=transform.Method.AVG,
+        timezone=None
+    )
+
+.. note::
+    Before version 1.17 the default value of ``timezone`` was ``UTC``.
+    This meant that to correctly transform a time zone-aware time series the
+    ``timezone`` argument had to be explicitly set to ``None``.
+    Starting from version 1.17 the default is ``None``, so the argument can
+    be omitted.

--- a/docs/source/time_zone_aware_timeseries.rst
+++ b/docs/source/time_zone_aware_timeseries.rst
@@ -34,10 +34,9 @@ See also the following examples:
 * :ref:`examples:Time zone-aware time series conversion`
 
 
-Transforming time zone-aware time series 2
-===========================================
-
-
+Transforming time zone-aware time series
+========================================
+
 When transforming a time zone-aware time series using
 :py:meth:`volue.mesh.calc.transform.TransformFunctions.transform`, the
 ``timezone`` argument must be set to ``None``.
@@ -56,7 +55,7 @@ When transforming a time zone-aware time series using
 
 .. note::
     Before version 1.17 the default value of ``timezone`` was ``UTC``.
-    This meant that to correctly transform a time zone-aware time series the
+    This meant that to correctly transform a time zone-aware time series, the
     ``timezone`` argument had to be explicitly set to ``None``.
     Starting from version 1.17 the default is ``None``, so the argument can
     be omitted.

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -28,7 +28,7 @@ Changes
 - **Breaking change:** The default value of the ``timezone`` argument in
   :py:meth:`~volue.mesh.calc.transform.TransformFunctions.transform` has
   been changed from ``UTC`` to ``None``. Code that relied on the previous
-  ``UTC`` default without passing the argument explicitly should now pass
+  ``UTC`` default without passing the argument explicitly must now explicitly pass
   ``timezone=Timezone.UTC``.
 
 Install instructions

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -25,7 +25,11 @@ New features
 Changes
 ~~~~~~~~~~~~~~~~~~
 
-- TBA
+- **Breaking change:** The default value of the ``timezone`` argument in
+  :py:meth:`~volue.mesh.calc.transform.TransformFunctions.transform` has
+  been changed from ``UTC`` to ``None``. Code that relied on the previous
+  ``UTC`` default without passing the argument explicitly should now pass
+  ``timezone=Timezone.UTC``.
 
 Install instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/volue/mesh/calc/transform.py
+++ b/src/volue/mesh/calc/transform.py
@@ -117,18 +117,18 @@ class _TransformFunctionsBase(_Calculation, ABC):
         self,
         resolution: Timeseries.Resolution,
         method: Method,
-        timezone: Timezone = Timezone.UTC,
+        timezone: Timezone | None = None,
         search_query: str | None = None,
     ) -> Timeseries:
         """
-        Transforms time series from one resolution to another resolution.
+        Transforms time series from one resolution to another resolution using ad-hoc calculation.
+        See `Mesh documentation about transform functions <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/>`__.
 
         Some of target resolutions have a time zone foundation.
         Note: the `LOCAL` and `STANDARD` time zone refers to time zone of Mesh server, not the Python client.
 
         Example:
             `DAY` can be related to European Standard Time (UTC+1), which is different from the DAY scope in Finland (UTC+2).
-            When the time zone argument to TRANSFORM is omitted, the configured standard time zone with no Daylight Saving Time enabled is used.
             You can use it to convert both ways, i.e. both from finer to coarser resolution, and the other way.
             The most common use is accumulation, i.e. transformation to coarser resolution.
             Most transformation methods are available for this latter use.
@@ -136,7 +136,9 @@ class _TransformFunctionsBase(_Calculation, ABC):
         Args:
             resolution: The resolution to transform to.
             method: What method to use for the transformation.
-            timezone: What time zone to use for the transformation.
+            timezone: What time zone to use for the transformation. If not set then the
+              `TRANSFORM(t,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s>`__ is used,
+              otherwise `TRANSFORM(t,s,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s-s>`__ is used.
             search_query: a search formulated using the `Mesh search language <https://volue-public.github.io/energy-smp-docs/latest/mesh/concepts/search-language/>`__.
 
         Note:
@@ -155,7 +157,7 @@ class TransformFunctions(_TransformFunctionsBase):
         self,
         resolution: Timeseries.Resolution,
         method: Method,
-        timezone: Timezone = Timezone.UTC,
+        timezone: Timezone | None = None,
         search_query: str | None = None,
     ) -> Timeseries:
         expression = super()._transform_expression(
@@ -172,7 +174,7 @@ class TransformFunctionsAsync(_TransformFunctionsBase):
         self,
         resolution: Timeseries.Resolution,
         method: Method,
-        timezone: Timezone = Timezone.UTC,
+        timezone: Timezone | None = None,
         search_query: str | None = None,
     ) -> Timeseries:
         expression = super()._transform_expression(

--- a/src/volue/mesh/calc/transform.py
+++ b/src/volue/mesh/calc/transform.py
@@ -121,7 +121,8 @@ class _TransformFunctionsBase(_Calculation, ABC):
         search_query: str | None = None,
     ) -> Timeseries:
         """
-        Transforms time series from one resolution to another resolution using ad-hoc calculation.
+        Transforms time series from one resolution to another. This is done using an ad-hoc calculation
+        which in turn uses the `TRANSFORM` calculation function.
         See `Mesh documentation about transform functions <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/>`__.
 
         Some of target resolutions have a time zone foundation.
@@ -136,10 +137,10 @@ class _TransformFunctionsBase(_Calculation, ABC):
         Args:
             resolution: The resolution to transform to.
             method: What method to use for the transformation.
-            timezone: What time zone to use for the transformation. If not set then the
-              `TRANSFORM(t,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s>`__ is used,
-              otherwise `TRANSFORM(t,s,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s-s>`__ is used.
-            search_query: a search formulated using the `Mesh search language <https://volue-public.github.io/energy-smp-docs/latest/mesh/concepts/search-language/>`__.
+            timezone: What time zone to use for the transformation. If not set, the
+              `TRANSFORM(t,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s>`__ overload is used,
+              otherwise the `TRANSFORM(t,s,s,s) <https://volue-public.github.io/energy-smp-docs/latest/mesh/calculations/functions/transform/#transformt-s-s-s>`__ overload is used.
+           search_query: a search formulated using the `Mesh search language <https://volue-public.github.io/energy-smp-docs/latest/mesh/concepts/search-language/>`__.
 
         Note:
             The resulting objects from the `search_query` will be used in the `transform` function, if `search_query` is not set the `target` will be used.


### PR DESCRIPTION
- change default value of  `timezone` argument from `UTC` to `None` in `transform` function - mark it as a **breaking change**.
- add more information to the time zone-aware time series docs
- extend/improve `transform` function docstrings.