### PR TITLE
handle `WriteTimeseries` RPC changes

### DIFF
--- a/src/volue/mesh/tests/test_timeseries.py
+++ b/src/volue/mesh/tests/test_timeseries.py
@@ -608,7 +608,10 @@ def test_write_timeseries_points_to_calculation_timeseries(session):
         table=new_table, full_name=TIME_SERIES_ATTRIBUTE_WITH_CALCULATION_PATH
     )
 
-    with pytest.raises(grpc.RpcError, match="not found"):
+    # Starting from Mesh 2.23 the error message has changed.
+    # Handle both cases for "some time".
+    error_message_regex = "(not found)|(target time series is not connected to a physical time series nor marked as session series)"
+    with pytest.raises(grpc.RpcError, match=error_message_regex):
         session.write_timeseries_points(timeseries)
 
 


### PR DESCRIPTION
In Mesh 2.23 (via https://github.com/Volue/energy-mesh/pull/9069) one of the `WriteTimeseries` RPC error messages has changed. Handle both: old and new message format.