### PR TITLE
generate test results in long tests

### DIFF
--- a/.github/workflows/long_tests.yml
+++ b/.github/workflows/long_tests.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ success() && env.NEW_COMMITS > 0 }}
         working-directory: ${{ github.workspace }}
         run: |
-          poetry run pytest -m "long"
+          poetry run pytest -m "long" --junitxml=TestResults/unittests.xml --cov=volue.mesh --cov-branch --cov-report=json:TestResults/coverage.json
 
       # ---- Quality Reporter ----------------------------------------------
       # Publishes test results and coverage to the Volue Grafana Code Quality


### PR DESCRIPTION
I missed that in https://github.com/Volue-Public/energy-mesh-python/pull/638 when moving the QR workflow to long_tests.yml