### PR TITLE
Run more tests for test coverage

### DIFF
--- a/.github/workflows/long_tests.yml
+++ b/.github/workflows/long_tests.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ success() && env.NEW_COMMITS > 0 }}
         working-directory: ${{ github.workspace }}
         run: |
-          poetry run pytest -m "long" --junitxml=TestResults/unittests.xml --cov=volue.mesh --cov-branch --cov-report=json:TestResults/coverage.json
+          poetry run pytest -m "not authentication" --junitxml=TestResults/unittests.xml --cov=volue.mesh --cov-branch --cov-report=json:TestResults/coverage.json
 
       # ---- Quality Reporter ----------------------------------------------
       # Publishes test results and coverage to the Volue Grafana Code Quality


### PR DESCRIPTION
Run all tests except for authentication tests for the workflow that uploads test coverage results to Volue QR.